### PR TITLE
Provide some links for terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ This is still in concept stage, and these issues are left to explore:
 - [X] Should Processors be called Presenters? (Went with Transformers)
 - [X] Simplify the assosciation of nested items. Move to a register method? 
 - [ ] Switch return array to use instance properties in `transform()`
-- [ ] Implement HATEOAS/HAL links
+- [ ] Implement [HATEOAS](http://en.wikipedia.org/wiki/HATEOAS)/[HAL](http://stateless.co/hal_specification.html )links
 - [ ] Support other pagination systems, not just `Illuminate\Pagination`
 
 


### PR DESCRIPTION
Provide links for HATEOAS and HAL, so you dont have to use $SEARCH_ENGINE ;-).

I dont know if these are the correct links but they look like the right ones.
