### PR TITLE
Allowing nested resources to be defined once, include=foo.bar will alias...

### DIFF
--- a/src/League/Fractal/Manager.php
+++ b/src/League/Fractal/Manager.php
@@ -59,6 +59,6 @@ class Manager
             }
         }
 
-        return $parsed;
+        return array_values(array_unique($parsed));
     }
 }

--- a/tests/League/Fractal/Test/ManagerTest.php
+++ b/tests/League/Fractal/Test/ManagerTest.php
@@ -15,8 +15,12 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testGetRequestedScopes()
     {
         $manager = new Manager();
+        $manager->setRequestedScopes(array('foo', 'bar', 'baz', 'baz.bart'));
+        $this->assertEquals(array('foo', 'bar', 'baz', 'baz.bart'), $manager->getRequestedScopes());
+
+        $manager = new Manager();
         $manager->setRequestedScopes(array('foo', 'bar', 'baz.bart'));
-        $this->assertEquals(array('foo', 'bar', 'baz.bart'), $manager->getRequestedScopes());
+        $this->assertEquals(array('foo', 'bar', 'baz', 'baz.bart'), $manager->getRequestedScopes());
     }
 
     public function testCreateDataWithCallback()
@@ -28,7 +32,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         });
 
         $rootScope = $manager->createData($resource);
-        
+
         $this->assertInstanceOf('League\Fractal\Scope', $rootScope);
 
         $this->assertEquals(array('data' => array('foo' => 'bar')), $rootScope->toArray());

--- a/tests/League/Fractal/Test/ScopeTest.php
+++ b/tests/League/Fractal/Test/ScopeTest.php
@@ -45,13 +45,13 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     public function testGetCurrentScope()
     {
         $manager = new Manager();
-        
+
         $resource = new Item(array('name' => 'Larry Ullman'), function () {
         });
 
         $scope = new Scope($manager, $resource, 'book');
         $this->assertEquals($scope->getCurrentScope(), 'book');
-        
+
         $childScope = $scope->embedChildScope('author', $resource);
         $this->assertEquals('author', $childScope->getCurrentScope());
 
@@ -67,7 +67,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         });
 
         $scope = new Scope($manager, $resource, 'book');
-        
+
         $childScope = $scope->embedChildScope('author', $resource);
         $this->assertEquals(array('book'), $childScope->getParentScopes());
 
@@ -81,9 +81,10 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $manager->setRequestedScopes(array('foo', 'bar', 'baz.bart'));
 
         $scope = new Scope($manager, m::mock('League\Fractal\Resource\ResourceInterface'));
-        
+
         $this->assertTrue($scope->isRequested('foo'));
         $this->assertTrue($scope->isRequested('bar'));
+        $this->assertTrue($scope->isRequested('baz'));
         $this->assertTrue($scope->isRequested('baz.bart'));
         $this->assertFalse($scope->isRequested('nope'));
 
@@ -117,7 +118,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $resource = new Item(array('bar' => 'baz'), $transformer);
 
         $scope = new Scope($manager, $resource);
-        
+
         $this->assertEquals(array('data' => array('bar' => 'baz'), 'embeds' => array('book')), $scope->toArray());
     }
 
@@ -134,7 +135,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $scope->pushParentScope('book'));
         $this->assertEquals(2, $scope->pushParentScope('author'));
         $this->assertEquals(3, $scope->pushParentScope('profile'));
-        
+
         $this->assertEquals(array('book', 'author', 'profile'), $scope->getParentScopes());
     }
 


### PR DESCRIPTION
... include=foo,foo.bar

Signed-off-by: Ben Corlett bencorlett@me.com
