### PR TITLE
Support Illuminate\Pagination\Paginator from 4.2-dev+

### DIFF
--- a/src/Pagination/IlluminatePaginatorAdapter.php
+++ b/src/Pagination/IlluminatePaginatorAdapter.php
@@ -28,7 +28,7 @@ class IlluminatePaginatorAdapter extends Paginator implements PaginatorInterface
     public function __construct(Paginator $paginator)
     {
         parent::__construct(
-            $paginator->getEnvironment(),
+            (method_exists($paginator, 'getFactory') ? $paginator->getFactory() : $paginator->getEnvironment()),
             $paginator->getItems(),
             $paginator->getTotal(),
             $paginator->getPerPage()


### PR DESCRIPTION
From version 4.2-dev Environment is renamed to Factory.
Added a method_exists() check to use the one existing.

The tests will probably fail when it begins using version 4.2.
