### PR TITLE
Add require PHP 5.3 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
             "role": "Developer"
         }
     ],
+    "require": {
+        "php": ">=5.3"
+    },
     "require-dev": {
         "illuminate/pagination": "~4.1",
         "league/phpunit-coverage-listener": "~1.1",


### PR DESCRIPTION
Why not add the PHP version requirement to composer.json like suggested in #31?
