### PR TITLE
[WIP] Create TransformerInterface, add FieldFilterTransformer implementing partial field functionality

### DIFF
--- a/src/FieldFilterTransformer.php
+++ b/src/FieldFilterTransformer.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace League\Fractal;
+
+class FieldFilterTransformer extends NestedTransformerAbstract
+{
+    /**
+     * Requested fields
+     * 
+     * @var array
+     */
+    protected $fields = array();
+
+    /**
+     * Allowed fields
+     * 
+     * @var array
+     */
+    protected $allowedFields = array();
+
+    /**
+     * Partial names to include
+     * 
+     * @var array
+     */
+    protected $partials = array();
+
+    /**
+     * Mapping of partial names to fields 
+     * 
+     * @var array
+     */
+    protected $partialFields = array();
+
+    /**
+     * The default partials to include 
+     * 
+     * @var array
+     */
+    protected $defaultPartials = array();
+
+    public function transform($data)
+    {
+        return $this->filter(
+            parent::transform($data)
+        );
+    }
+
+    public function setAllowedFields(array $fields)
+    {
+        $this->allowedFields = $allowedFields;
+    }
+
+    public function setFields(array $fields)
+    {
+        $this->fields = $fields;
+    }
+
+    public function setPartialFields($partial, array $fields)
+    {
+        if ($this->allowedFields && ($invalidFields = array_diff($fields, $this->allowedFields))) {
+            throw new \InvalidArgumentException('The following fields are invalid: '.implode(', ', $invalidFields));
+        }
+
+        $this->partialFields[$partial] = $fields;
+    }
+
+    public function setPartials(array $partials)
+    {
+        $this->partials = $partials;
+    }
+
+    protected function filter(array $data)
+    {
+        if (empty($this->partials) && empty($this->fields)) {
+            return $data;
+        }
+
+        $whitelistFields = array_fill_keys($this->fields, true) ?: array();
+
+        if ($this->partials) {
+            foreach ($this->partials as $partial) {
+                foreach ($this->getFieldsForPartial($partial) as $field) {
+                    $whitelistFields[$field] = true;
+                }
+            }
+        }
+
+        $filtered = array();
+
+        foreach ($data as $field => $value) {
+            if (!isset($whitelistFields[$field])) {
+                continue;
+            }
+
+            $filtered[$field] = $value;
+        }
+
+        return $filtered;
+    }
+
+    protected function getFieldsForPartial($partial)
+    {
+        if (!isset($this->partialFields[$partial])) {
+            throw new \InvalidArgumentException(
+                'Invalid partial name: '.$partial.'. Valid partials: '.implode(', ', array_keys($this->partialFields))
+            );
+        }
+
+        return $this->partialFields[$partial];
+    }
+
+}

--- a/src/NestedTransformerAbstract.php
+++ b/src/NestedTransformerAbstract.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace League\Fractal;
+
+use League\Fractal\Scope;
+
+abstract class NestedTransformerAbstract implements TransformerInterface
+{
+    /**
+     * The transformer to use 
+     * 
+     * @var TransformerInterface
+     * @access protected
+     */
+    protected $transformer;
+
+    public function __construct(TransformerInterface $transformer)
+    {
+        $this->transformer = $transformer;
+    }
+
+    public function setTransformer(TransformerInterface $transformer)
+    {
+        $this->transformer = $transformer;
+    }
+
+    public function getAvailableEmbeds()
+    {
+        return $this->transformer->getAvailableEmbeds();
+    }
+
+    public function setAvailableEmbeds($availableEmbeds)
+    {
+        return $this->transformer->setAvailableEmbeds($availableEmbeds);
+    }
+
+    public function getDefaultEmbeds()
+    {
+        return $this->transformer->getDefaultEmbeds();
+    }
+
+    public function setDefaultEmbeds($defaultEmbeds)
+    {
+        $this->transformer->setDefaultEmbeds();
+    }
+
+    public function processEmbededResources(Scope $scope, $data)
+    {
+        $this->transformer->processEmbeddedResources();
+    }
+
+    public function transform($data)
+    {
+        return $this->transformer->transform($data);
+    }
+
+}

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -155,7 +155,7 @@ class Scope
         $processedData = call_user_func(array($transformer, 'transform'), $data);
 
         // If its an object, process potential embeded resources
-        if ($transformer instanceof TransformerAbstract) {
+        if ($transformer instanceof TransformerInterface) {
             $embededData = $transformer->processEmbededResources($this, $data);
 
             if ($embededData !== false) {

--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -183,6 +183,8 @@ abstract class TransformerAbstract implements TransformerInterface
         return $this;
     }
 
+    abstract public function transform($data);
+
     /**
      * Create a new item resource object
      *

--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -23,7 +23,7 @@ use League\Fractal\Resource\ResourceInterface;
  * the self::$availableEmbeds property available. Extends it and add a `transform()`
  * method to transform any data into a basic array, including embedded content.
  */
-abstract class TransformerAbstract
+abstract class TransformerAbstract implements TransformerInterface
 {
     /**
      * Embed if requested

--- a/src/TransformerInterface.php
+++ b/src/TransformerInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the League\Fractal package.
  *
- * (c) Phil Sturgeon <email@philsturgeon.co.uk>
+ * (c) Ben Glassman <bglassman@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -11,9 +11,7 @@
 
 namespace League\Fractal;
 
-use League\Fractal\Resource\Collection;
-use League\Fractal\Resource\Item;
-use League\Fractal\Resource\ResourceInterface;
+use League\Fractal\Scope;
 
 /**
  * Transformer Interface
@@ -28,4 +26,5 @@ interface TransformerInterface
     public function getDefaultEmbeds();
     public function setDefaultEmbeds($defaultEmbeds);
     public function processEmbededResources(Scope $scope, $data);
+    public function transform($data);
 }

--- a/src/TransformerInterface.php
+++ b/src/TransformerInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the League\Fractal package.
+ *
+ * (c) Phil Sturgeon <email@philsturgeon.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\Fractal;
+
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\Item;
+use League\Fractal\Resource\ResourceInterface;
+
+/**
+ * Transformer Interface
+ *
+ * All Transformer classes should extend the TransformerAbstract class
+ * or implement this interface themselves
+ */
+interface TransformerInterface
+{
+    public function getAvailableEmbeds();
+    public function setAvailableEmbeds($availableEmbeds);
+    public function getDefaultEmbeds();
+    public function setDefaultEmbeds($defaultEmbeds);
+    public function processEmbededResources(Scope $scope, $data);
+}


### PR DESCRIPTION
This is an example of one way that the partial field function we discussed could be implemented. This is a proof of concept and RFC.

I created a TransformerInterface which just provides the public methods that are used in the Scope class when interacting with TransformerAbstract. All the tests still pass and it doesnt make any real difference to type hint on TransformerInterface except to open up additional possibilities for implementations.

In this case we have a based implementation NestedTransformerAbstract which wraps around another transformer. Its abstract because by itself it does nothing, but FieldFilterTransformer wraps around another transformer but then filters by whitelisted fields.

Interested to hear your thoughts, there are certainly other ways to go about this but I do think that the transformer interface could be a nice way to increase flexibility of the library.

```php
class FooTransformer extends TransformerAbstract
{
    public function transform($data)
    {
        return $data;
    }
}

$transformer = new FooTransformer();
$fieldTransformer = new League\Fractal\FieldFilterTransformer($transformer);
$fieldTransformer->setFields(array('foo'));
$fieldTransformer->setPartialFields('stats', array(
    'count',
    'frequency'
));
$fieldTransformer->setPartials(array('stats'));

$data = array(
    'foo' => 'bar',
    'baz' => 'biz',
    'count' => 500,
    'frequency' => 0.5,
);

var_dump($fieldTransformer->transform($data));
```

Output
```shell
array(3) {
  'foo' =>
  string(3) "bar"
  'count' =>
  int(500)
  'frequency' =>
  double(0.5)
}
````