### PR TITLE
Use Manager::parseIncludes with TrasformerAbstract

### DIFF
--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -80,9 +80,9 @@ abstract class TransformerAbstract
     /**
      * Parse Includes wrapper
      *
-     * @return \League\Fractal\Scope
+     * 
      **/
-    public function setCurrentIncludes(Scope $scope, $data)
+    protected function setCurrentIncludes(Scope $scope, $data)
     {
         if (isset($data)) {
             $scope->getManager()->parseIncludes($data);


### PR DESCRIPTION
Creating a small change for TransformerAbstract for use parseIncludes into it.
(PR for issue #67 )
