### PR TITLE
Updated cursor documentation

### DIFF
--- a/source/pagination.md
+++ b/source/pagination.md
@@ -63,9 +63,9 @@ use League\Fractal\Pagination\Cursor;
 use League\Fractal\Resource\Collection;
 
 if ($currentCursorStr = Input::get('cursor', false)) {
-        $books = Book::where('id', '>', $currentCursorStr)->take(5)->get();
+    $books = Book::where('id', '>', $currentCursorStr)->take(5)->get();
 } else {
-        $books = Book::take(5)->get();  
+    $books = Book::take(5)->get();  
 }
 
 $prevCursorStr = Input::get('prevCursor', 6); // If prevCursor is not present, then indicate to fetch the first five results instead.


### PR DESCRIPTION
Hi, thanks for Fractal; it's been a big help in one of my projects. I was reading the documentation online and noticed that the argument for previous cursor was not present; I feel that this may confuse people until they look at the implementation of the default constructor in the Cursor class. I am submitting a small change to the documentation to explicitly show that there is an option for a previous cursor value. Please let me know if there are any thoughts; I am new to Github and git so I am sorry if I have done something incorrectly.
