### PR TITLE
Added a .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto
+
+/test export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml export-ignore
+/Guardfile export-ignore
+/phpunit.xml.dist export-ignore
+/CHANGELOG.md export-ignore
+/CONTRIBUTING.md export-ignore
+/README.md export-ignore


### PR DESCRIPTION
This is so when people are installing this through composer, they only get the required source files. This saves disk space for the user, and saves github's bandwidth.
