### PR TITLE
QueryString is now appended to page links

### DIFF
--- a/src/Pagination/IlluminatePaginatorAdapter.php
+++ b/src/Pagination/IlluminatePaginatorAdapter.php
@@ -50,4 +50,32 @@ class IlluminatePaginatorAdapter extends Paginator implements PaginatorInterface
     {
         return $this->count();
     }
+    
+    /**
+     * Override method so includes work with pagination
+     * @param  Int $page 
+     * @return String       
+     */
+    public function getUrl($page)
+    {
+        $parameters = array(
+            $this->factory->getPageName() => $page,
+        );
+
+        // append the querystring to the pagination links
+        $queryStrings = array_except( \Input::query(), $this->factory->getPageName() );
+        $this->appends($queryStrings);
+
+        // If we have any extra query string key / value pairs that need to be added
+        // onto the URL, we will put them in query string form and then attach it
+        // to the URL. This allows for extra information like sortings storage.
+        if (count($this->query) > 0)
+        {
+            $parameters = array_merge($parameters, $this->query);
+        }
+
+        $fragment = $this->buildFragment();
+
+        return $this->factory->getCurrentUrl().'?'.http_build_query($parameters, null, '&').$fragment;
+    }    
 }


### PR DESCRIPTION
I need  append to page links the query string (&category_id=2 for example).
This code allows do it
