### PR TITLE
Remove array() when serialize an item resource in JsonApiSerializer

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -36,7 +36,7 @@ class JsonApiSerializer extends ArraySerializer
      */
     public function item($resourceKey, array $data)
     {
-        return array($resourceKey ?: 'data' => array($data));
+        return array($resourceKey ?: 'data' => $data);
     }
 
     /**


### PR DESCRIPTION
According the JSON API specification an individual resource SHOULD be represented as a single "resource object" (described below) or a string value containing its ID (http://jsonapi.org/format/#document-structure-resource-representations).

So I changed JsonApiSerializer to represent single item as single oblect.
