### PR TITLE
Remove getPaginator() from PaginatorInterface

### DIFF
--- a/src/Pagination/PaginatorInterface.php
+++ b/src/Pagination/PaginatorInterface.php
@@ -49,5 +49,4 @@ interface PaginatorInterface
      * @return string
      */
     public function getUrl($page);
-    public function getPaginator();
 }


### PR DESCRIPTION
What is the need and the output of the method `PaginatorInterface::getPaginator()`? I couldn't find any use or tests for this method. But I have to declare it in my Paginator? Why should a Paginator return itself?

There might be a need for this method in [IlluminatePaginatorAdapter](https://github.com/thephpleague/fractal/blob/master/src/Pagination/IlluminatePaginatorAdapter.php#L98), but not in the Interface.
