### PR TITLE
Update JsonApiSerializer.php

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -36,7 +36,7 @@ class JsonApiSerializer extends ArraySerializer
      */
     public function item($resourceKey, array $data)
     {
-        return array($resourceKey ?: 'data' => array($data));
+        return array($resourceKey ?: 'data' => $data);
     }
 
     /**


### PR DESCRIPTION
If you are going off of http://jsonapi.org, single item's should return as nested key value pairs underneath the resource key. They should not be returning inside of an array (Since, there should only be one item returning, as far as I could tell)

http://jsonapi.org/format/#document-structure-individual-resource-representations

Current (And, from what I can tell, incorrect)

```
{
    "data": [
        {
            "key": "value"
             ......
        }
    ]
}
```

Updated as part of this pull request

```
{
    "data": {
            "key": "value"
             ......
        }
}
```
