### PR TITLE
Methods getLastPage() and getCurrentPage() should return integer

### DIFF
--- a/src/Pagination/IlluminatePaginatorAdapter.php
+++ b/src/Pagination/IlluminatePaginatorAdapter.php
@@ -38,7 +38,7 @@ class IlluminatePaginatorAdapter implements PaginatorInterface
 
     /**
      * Get current page
-     * @return string
+     * @return integer
      */
     public function getCurrentPage()
     {
@@ -47,7 +47,7 @@ class IlluminatePaginatorAdapter implements PaginatorInterface
 
     /**
      * Get last page
-     * @return string
+     * @return integer
      */
     public function getLastPage()
     {

--- a/src/Pagination/PaginatorInterface.php
+++ b/src/Pagination/PaginatorInterface.php
@@ -19,12 +19,12 @@ namespace League\Fractal\Pagination;
 interface PaginatorInterface
 {
     /**
-     * @return string
+     * @return integer
      */
     public function getCurrentPage();
 
     /**
-     * @return string
+     * @return integer
      */
     public function getLastPage();
 


### PR DESCRIPTION
Methods getLastPage() and getCurrentPage() should return integer. This is atleast according to [ArraySerializer::paginator()](https://github.com/thephpleague/fractal/blob/master/src/Serializer/ArraySerializer.php#L76) where both are typecasted to integer. PR changes the docblock return values  from `string` to `integer`. 

``` php
$currentPage = (int) $paginator->getCurrentPage();
$lastPage = (int) $paginator->getLastPage();

$pagination = array(
    'total' => (int) $paginator->getTotal(),
    'count' => (int) $paginator->getCount(),
    'per_page' => (int) $paginator->getPerPage(),
    'current_page' => $currentPage,
    'total_pages' => $lastPage,
);
```
