### PR TITLE
Allow transformer/resourceKey to come from resource.

### DIFF
--- a/src/Resource/ResourceAbstract.php
+++ b/src/Resource/ResourceAbstract.php
@@ -48,10 +48,22 @@ abstract class ResourceAbstract implements ResourceInterface
      * @param  callable|string  $transformer
      * @param  string  $resourceKey
      */
-    public function __construct($data, $transformer, $resourceKey = null)
+    public function __construct($data, $transformer = null, $resourceKey = null)
     {
         $this->data = $data;
+
+        if (! $transformer) {
+            if (is_object($data) && is_callable(array($data, 'getTransformer'))) {
+                $transformer = $data->getTransformer();
+            } else {
+                throw new \InvalidArgumentException('A valid resource transformer is required.');
+            }
+        }
         $this->transformer = $transformer;
+
+        if (is_null($resourceKey) && is_object($data) && is_callable(array($data, 'getResourceKey'))) {
+            $resourceKey = $data->getResourceKey();
+        }
         $this->resourceKey = $resourceKey;
     }
 


### PR DESCRIPTION
I'm wondering if a change like this is desirable? It would allow a little more flexibility in initializing resources; I usually extend the Item and Collection classes or create a wrapper handler because I only need to pass in $data.

I'm using Laravel, and since my $data is almost always an Eloquent model, I can just have the model provide the default transformer and resourceKey. Obviously, with this change a user could still pass in a transformer to override the default, and a string (or `false` for none) for resourceKey to override that.

This is a sorta breaking change, in that if `$data` has the method `getResourceKey` on it and the user doesn't provide a resourceKey when initializing the resource, then the behavior will have changed from previous versions. (I don't think the same can be said of transformers however, as they were previously required anyway.)

I'll finish out the feature (docs, etc) if this is something you're interested in...