### PR TITLE
Add an abstract transform() function to TransformerAbstract.php

### DIFF
--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -77,6 +77,8 @@ abstract class TransformerAbstract
         return $this->currentScope;
     }
 
+    public abstract function transform($data);
+
     /**
      * @internal
      * @param Scope $scope

--- a/test/Stub/Transformer/DefaultIncludeBookTransformer.php
+++ b/test/Stub/Transformer/DefaultIncludeBookTransformer.php
@@ -8,7 +8,7 @@ class DefaultIncludeBookTransformer extends TransformerAbstract
         'author'
     );
 
-    public function transform()
+    public function transform($data)
     {
         return array('a' => 'b');
     }

--- a/test/Stub/Transformer/GenericAuthorTransformer.php
+++ b/test/Stub/Transformer/GenericAuthorTransformer.php
@@ -4,7 +4,7 @@ use League\Fractal\TransformerAbstract;
 
 class GenericAuthorTransformer extends TransformerAbstract
 {
-    public function transform(array $author)
+    public function transform($author)
     {
         return $author;
     }

--- a/test/Stub/Transformer/GenericBookTransformer.php
+++ b/test/Stub/Transformer/GenericBookTransformer.php
@@ -8,7 +8,7 @@ class GenericBookTransformer extends TransformerAbstract
         'author'
     );
 
-    public function transform(array $book)
+    public function transform($book)
     {
         return array(
             'title' => $book['title'],


### PR DESCRIPTION
It bothered me while creating new transformers that PHPStorm didn't notify me, that I need to implement transform($data).

I removed type-hinting an array for some implementations, since it could transform every datastructure, right?
