### PR TITLE
Add ``data`` key to ArraySerializer() collection example.

### DIFF
--- a/serializers.md
+++ b/serializers.md
@@ -138,7 +138,7 @@ $manager->setSerializer(new ArraySerializer());
 
 // Collection
 [
-    [
+    'data' => [
         'foo' => 'bar'
     ]
 ];


### PR DESCRIPTION
Updates documentation to reflect the real behavior of `ArraySerializer()` on collections.
