### PR TITLE
Removed `@api` annotations

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -64,8 +64,6 @@ class Manager
      *
      * Main method to kick this all off. Make a resource then pass it over, and use toArray()
      *
-     * @api
-     *
      * @param ResourceInterface $resource
      * @param string            $scopeIdentifier
      * @param Scope             $parentScopeInstance
@@ -91,8 +89,6 @@ class Manager
     /**
      * Get Include Params.
      *
-     * @api
-     *
      * @param string $include
      *
      * @return \League\Fractal\ParamBag|null
@@ -111,8 +107,6 @@ class Manager
     /**
      * Get Requested Includes.
      *
-     * @api
-     *
      * @return array
      */
     public function getRequestedIncludes()
@@ -122,8 +116,6 @@ class Manager
 
     /**
      * Get Serializer.
-     *
-     * @api
      *
      * @return SerializerAbstract
      */
@@ -138,8 +130,6 @@ class Manager
 
     /**
      * Parse Include String.
-     *
-     * @api
      *
      * @param array|string $includes Array or csv string of resources to include
      *
@@ -208,8 +198,6 @@ class Manager
     /**
      * Set Recursion Limit.
      *
-     * @api
-     *
      * @param int $recursionLimit
      *
      * @return $this
@@ -223,8 +211,6 @@ class Manager
 
     /**
      * Set Serializer
-     *
-     * @api
      *
      * @param SerializerAbstract $serializer
      *

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -190,8 +190,6 @@ class Scope
     /**
      * Convert the current data for this scope to an array.
      *
-     * @api
-     *
      * @return array
      */
     public function toArray()
@@ -230,8 +228,6 @@ class Scope
 
     /**
      * Convert the current data for this scope to JSON.
-     *
-     * @api
      *
      * @return string
      */

--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -196,8 +196,6 @@ abstract class TransformerAbstract
     /**
      * Setter for availableIncludes.
      *
-     * @api
-     *
      * @param array $availableIncludes
      *
      * @return $this
@@ -211,8 +209,6 @@ abstract class TransformerAbstract
 
     /**
      * Setter for defaultIncludes.
-     *
-     * @api
      *
      * @param array $defaultIncludes
      *
@@ -228,8 +224,6 @@ abstract class TransformerAbstract
     /**
      * Setter for currentScope.
      *
-     * @api
-     *
      * @param Scope $currentScope
      *
      * @return $this
@@ -244,8 +238,6 @@ abstract class TransformerAbstract
     /**
      * Create a new item resource object.
      *
-     * @api
-     *
      * @param mixed                        $data
      * @param TransformerAbstract|callable $transformer
      * @param string                       $resourceKey
@@ -259,8 +251,6 @@ abstract class TransformerAbstract
 
     /**
      * Create a new collection resource object.
-     *
-     * @api
      *
      * @param mixed                        $data
      * @param TransformerAbstract|callable $transformer


### PR DESCRIPTION
A fair few methods are actually missing the `@api` annotation that should really have it. I propose we simply remove all existing `@api` annotations, and let it be assumed that methods are for public use unless specified as `@internal`.
