### PR TITLE
Including the resource once if an 'id' is present.

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -50,10 +50,23 @@ class JsonApiSerializer extends ArraySerializer
     public function includedData($resourceKey, array $data)
     {
         $serializedData = array();
-
+        $linkedIds = array();
         foreach ($data as $value) {
             foreach ($value as $includeKey => $includeValue) {
-                $serializedData = array_merge_recursive($serializedData, $includeValue);
+                foreach ($includeValue[$includeKey] as $itemValue) {
+                    if (!array_key_exists('id', $itemValue)) {
+                        $serializedData[$includeKey][] = $itemValue;
+                        continue;
+                    }
+
+                    $itemId = $itemValue['id'];
+                    if (!empty($linkedIds[$includeKey]) && in_array($itemId, $linkedIds[$includeKey], true)) {
+                        continue;
+                    }
+
+                    $serializedData[$includeKey][] = $itemValue;
+                    $linkedIds[$includeKey][] = $itemId;
+                }
             }
         }
 

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -238,6 +238,58 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expectedJson, $scope->toJson());
     }
 
+    public function testSerializingCollectionResourceWithDuplicatedIncludeData() {
+        $this->manager->parseIncludes('author');
+
+        $booksData = array(
+            array(
+                'title' => 'Foo',
+                'year' => '1991',
+                '_author' => array(
+                    'id' => 1,
+                    'name' => 'Dave',
+                ),
+            ),
+            array(
+                'title' => 'Bar',
+                'year' => '1997',
+                '_author' => array(
+                    'id' => 1,
+                    'name' => 'Dave',
+                ),
+            ),
+        );
+
+        $resource = new Collection($booksData, new GenericBookTransformer(), 'book');
+        $scope = new Scope($this->manager, $resource);
+
+        $expected = array(
+            'book' => array(
+                array(
+                    'title' => 'Foo',
+                    'year' => 1991,
+                ),
+                array(
+                    'title' => 'Bar',
+                    'year' => 1997,
+                ),
+            ),
+            'linked' => array(
+                'author' => array(
+                    array(
+                        'id' => 1,
+                        'name' => 'Dave',
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertEquals($expected, $scope->toArray());
+
+        $expectedJson = '{"book":[{"title":"Foo","year":1991},{"title":"Bar","year":1997}],"linked":{"author":[{"id":1,"name":"Dave"}]}}';
+        $this->assertEquals($expectedJson, $scope->toJson());
+    }
+
     public function testResourceKeyMissing()
     {
         $this->manager->setSerializer(new JsonApiSerializer());

--- a/test/Stub/Transformer/GenericBookTransformer.php
+++ b/test/Stub/Transformer/GenericBookTransformer.php
@@ -10,10 +10,10 @@ class GenericBookTransformer extends TransformerAbstract
 
     public function transform(array $book)
     {
-        return array(
-            'title' => $book['title'],
-            'year' => (int) $book['year'],
-        );
+        $book['year'] = (int) $book['year'];
+        unset($book['_author']);
+
+        return $book;
     }
 
     public function includeAuthor(array $book)


### PR DESCRIPTION
Fix #84

From the Specification:

> Each resource object SHOULD contain a unique identifier, or ID, when available.
