### PR TITLE
Allowing to use the same sideload key in multiple transformers

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -205,7 +205,7 @@ class Scope
         if ($serializer->sideloadIncludes()) {
             $includedData = $serializer->includedData($this->resource, $rawIncludedData);
 
-            $data = array_merge($data, $includedData);
+            $data = array_merge_recursive($data, $includedData);
         }
 
         if ($this->resource instanceof Collection) {


### PR DESCRIPTION
Sometimes there is a relationship in which Model 1 belongs to Model 2 which has Model 1. If one try to write transformer for them the key from the last transformer is going to replace first. I know, hard to understand. Maybe an example?

![diagram](https://cloud.githubusercontent.com/assets/5459938/5140733/0ac31700-716e-11e4-9fcc-ddbe69d3a9c2.png)

And situation in which one is going to display a list of urls with urls that are redirecting to them. The API need to pass 1 sideloaded block not two (for instance urls incoming, urls outgoing). 
This pull request fix the problem.