### PR TITLE
Pass the scope identifier into the serializer item and collection method

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -281,9 +281,9 @@ class Scope
         $resourceKey = $this->resource->getResourceKey();
 
         if ($this->resource instanceof Collection) {
-            return $serializer->collection($resourceKey, $data);
+            return $serializer->collection($resourceKey, $data, $this->scopeIdentifer);
         } else {
-            return $serializer->item($resourceKey, $data);
+            return $serializer->item($resourceKey, $data, $this->scopeIdentifer);
         }
     }
 

--- a/src/Serializer/ArraySerializer.php
+++ b/src/Serializer/ArraySerializer.php
@@ -21,10 +21,11 @@ class ArraySerializer extends SerializerAbstract
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string $scopeIdentifier
      *
      * @return array
      */
-    public function collection($resourceKey, array $data)
+    public function collection($resourceKey, array $data, $scopeIdentifier)
     {
         return array($resourceKey ?: 'data' => $data);
     }
@@ -34,10 +35,11 @@ class ArraySerializer extends SerializerAbstract
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string $scopeIdentifier
      *
      * @return array
      */
-    public function item($resourceKey, array $data)
+    public function item($resourceKey, array $data, $scopeIdentifier)
     {
         return $data;
     }

--- a/src/Serializer/DataArraySerializer.php
+++ b/src/Serializer/DataArraySerializer.php
@@ -18,10 +18,11 @@ class DataArraySerializer extends ArraySerializer
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string $scopeIdentifier
      *
      * @return array
      */
-    public function collection($resourceKey, array $data)
+    public function collection($resourceKey, array $data, $scopeIdentifier)
     {
         return array('data' => $data);
     }
@@ -31,10 +32,11 @@ class DataArraySerializer extends ArraySerializer
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string $scopeIdentifier
      *
      * @return array
      */
-    public function item($resourceKey, array $data)
+    public function item($resourceKey, array $data, $scopeIdentifier)
     {
         return array('data' => $data);
     }

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -18,10 +18,11 @@ class JsonApiSerializer extends ArraySerializer
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string $scopeIdentifier
      *
      * @return array
      */
-    public function collection($resourceKey, array $data)
+    public function collection($resourceKey, array $data, $scopeIdentifier)
     {
         return array($resourceKey ?: 'data' => $data);
     }
@@ -31,10 +32,11 @@ class JsonApiSerializer extends ArraySerializer
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string $scopeIdentifier
      *
      * @return array
      */
-    public function item($resourceKey, array $data)
+    public function item($resourceKey, array $data, $scopeIdentifier)
     {
         return array($resourceKey ?: 'data' => array($data));
     }

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -21,20 +21,22 @@ abstract class SerializerAbstract
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string $scopeIdentifier
      *
      * @return array
      */
-    abstract public function collection($resourceKey, array $data);
+    abstract public function collection($resourceKey, array $data, $scopeIdentifier);
 
     /**
      * Serialize an item.
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string $scopeIdentifier
      *
      * @return array
      */
-    abstract public function item($resourceKey, array $data);
+    abstract public function item($resourceKey, array $data, $scopeIdentifier);
 
     /**
      * Serialize the included data.


### PR DESCRIPTION
This is a small change that I believe will add more flexibility to the serialization process. 

This change will do two things:

1) Access the name of the include for the resource being serialized.
2) More importantly, allow you to tell whether the resource being serialized is a 'root' resource or not; if there is a $scopeIdentifier then we know we are dealing with a nested resource, otherwise we have a root resource.

For point 2, a change was made in an earlier version that created the separate ```item``` and ```collection``` methods for more flexibility. Knowing whether or not you are dealing with a root resource or a nested resource will provide even greater flexibility.

This would be very beneficial for a serializer I am writing to sideload data for Ember.js.