### PR TITLE
Addition to pagination page - how to reintroduce query strings into generated paginated links

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -55,7 +55,7 @@ the last line above with:
 ~~~ php
 $paginatorAdapter = new IlluminatePaginatorAdapter($paginator);
 
-foreach (Input::except('page') as $key => $value) {
+foreach ( array_diff_key($_GET, array_flip(['page']) ) as $key => $value) {
 	$paginatorAdapter->addQuery($key, $value);
 }
 


### PR DESCRIPTION
This one was a head scratcher for me for a bit, hoping to save someone else the grief of figuring it out. I figure query strings as a way of filtering results is fairly common and needs to be persistent from page to page.
