### PR TITLE
JsonAPI: Including one level of `linked` data

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -56,23 +56,69 @@ class JsonApiSerializer extends ArraySerializer
         foreach ($data as $value) {
             foreach ($value as $includeKey => $includeValue) {
                 foreach ($includeValue[$includeKey] as $itemValue) {
-                    if (!array_key_exists('id', $itemValue)) {
-                        $serializedData[$includeKey][] = $itemValue;
-                        continue;
-                    }
-
-                    $itemId = $itemValue['id'];
-                    if (!empty($linkedIds[$includeKey]) && in_array($itemId, $linkedIds[$includeKey], true)) {
+                    if (!$this->shouldIncludeData($includeKey, $itemValue, $linkedIds)) {
                         continue;
                     }
 
                     $serializedData[$includeKey][] = $itemValue;
-                    $linkedIds[$includeKey][] = $itemId;
+                    $linkedIds[$includeKey][] = $itemValue['id'];
+                }
+
+                if (!empty($includeValue['linked'])) {
+                    $serializedData = array_merge_recursive(
+                        $serializedData,
+                        $this->includedLinkedData($includeValue['linked'], $linkedIds)
+                    );
                 }
             }
         }
 
         return empty($serializedData) ? array() : array('linked' => $serializedData);
+    }
+
+    /**
+     * Include data from the 'linked' section.
+     *
+     * @param array $data
+     * @param array $linkedIds
+     *
+     * @return array
+     */
+    protected function includedLinkedData(array $data, array &$linkedIds)
+    {
+        $serializedData = array();
+        foreach ($data as $includeKey => $values) {
+            foreach ($values as $itemValue) {
+                if (!$this->shouldIncludeData($includeKey, $itemValue, $linkedIds)) {
+                    continue;
+                }
+
+                $serializedData[$includeKey][] = $itemValue;
+                $linkedIds[$includeKey][] = $itemValue['id'];
+            }
+        }
+
+        return $serializedData;
+    }
+
+    /**
+     * Whether the data should be included.
+     *
+     * @param string $includeKey
+     * @param array $item
+     * @param array $linkedIds
+     *
+     * @return boolean False when there is no 'id' or id is already included. True otherwise
+     */
+    protected function shouldIncludeData($includeKey, array $item, array $linkedIds)
+    {
+        if (!array_key_exists('id', $item)) {
+            return false;
+        }
+        if (!empty($linkedIds[$includeKey]) && in_array($item['id'], $linkedIds[$includeKey], true)) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -24,7 +24,11 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $bookData = array(
             'title' => 'Foo',
             'year' => '1991',
+            'links' => array(
+                'author' => 1,
+            ),
             '_author' => array(
+                'id' => 1,
                 'name' => 'Dave',
             ),
         );
@@ -38,11 +42,15 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                 array(
                     'title' => 'Foo',
                     'year' => 1991,
+                    'links' => array(
+                        'author' => 1,
+                    ),
                 ),
             ),
             'linked' => array(
                 'author' => array(
                     array(
+                        'id' => 1,
                         'name' => 'Dave',
                     ),
                 ),
@@ -51,7 +59,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"book":[{"title":"Foo","year":1991}],"linked":{"author":[{"name":"Dave"}]}}';
+        $expectedJson = '{"book":[{"title":"Foo","year":1991,"links":{"author":1}}],"linked":{"author":[{"id":1,"name":"Dave"}]}}';
         $this->assertEquals($expectedJson, $scope->toJson());
     }
 
@@ -62,7 +70,11 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $bookData = array(
             'title' => 'Foo',
             'year' => '1991',
+            'links' => array(
+                'author' => 1,
+            ),
             '_author' => array(
+                'id' => 1,
                 'name' => 'Dave',
             ),
         );
@@ -76,11 +88,15 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                 array(
                     'title' => 'Foo',
                     'year' => 1991,
+                    'links' => array(
+                        'author' => 1,
+                    ),
                 ),
             ),
             'linked' => array(
                 'author' => array(
                     array(
+                        'id' => 1,
                         'name' => 'Dave',
                     ),
                 ),
@@ -89,7 +105,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"book":[{"title":"Foo","year":1991}],"linked":{"author":[{"name":"Dave"}]}}';
+        $expectedJson = '{"book":[{"title":"Foo","year":1991,"links":{"author":1}}],"linked":{"author":[{"id":1,"name":"Dave"}]}}';
         $this->assertEquals($expectedJson, $scope->toJson());
     }
 
@@ -101,14 +117,22 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             array(
                 'title' => 'Foo',
                 'year' => '1991',
+                'links' => array(
+                    'author' => 1,
+                ),
                 '_author' => array(
+                    'id' => 1,
                     'name' => 'Dave',
                 ),
             ),
             array(
                 'title' => 'Bar',
                 'year' => '1997',
+                'links' => array(
+                    'author' => 2,
+                ),
                 '_author' => array(
+                    'id' => 2,
                     'name' => 'Bob',
                 ),
             ),
@@ -122,23 +146,35 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                 array(
                     'title' => 'Foo',
                     'year' => 1991,
+                    'links' => array(
+                        'author' => 1,
+                    ),
                 ),
                 array(
                     'title' => 'Bar',
                     'year' => 1997,
+                    'links' => array(
+                        'author' => 2,
+                    ),
                 ),
             ),
             'linked' => array(
                 'author' => array(
-                    array('name' => 'Dave'),
-                    array('name' => 'Bob'),
+                    array(
+                        'id' => 1,
+                        'name' => 'Dave',
+                    ),
+                    array(
+                        'id' => 2,
+                        'name' => 'Bob',
+                    ),
                 ),
             ),
         );
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"book":[{"title":"Foo","year":1991},{"title":"Bar","year":1997}],"linked":{"author":[{"name":"Dave"},{"name":"Bob"}]}}';
+        $expectedJson = '{"book":[{"title":"Foo","year":1991,"links":{"author":1}},{"title":"Bar","year":1997,"links":{"author":2}}],"linked":{"author":[{"id":1,"name":"Dave"},{"id":2,"name":"Bob"}]}}';
         $this->assertEquals($expectedJson, $scope->toJson());
     }
 
@@ -149,7 +185,11 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $bookData = array(
             'title' => 'Foo',
             'year' => '1991',
+            'links' => array(
+                'author' => 1,
+            ),
             '_author' => array(
+                'id' => 1,
                 'name' => 'Dave',
             ),
         );
@@ -164,11 +204,15 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                 array(
                     'title' => 'Foo',
                     'year' => 1991,
+                    'links' => array(
+                        'author' => 1,
+                    ),
                 ),
             ),
             'linked' => array(
                 'author' => array(
                     array(
+                        'id' => 1,
                         'name' => 'Dave',
                     ),
                 ),
@@ -180,7 +224,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"book":[{"title":"Foo","year":1991}],"linked":{"author":[{"name":"Dave"}]},"meta":{"foo":"bar"}}';
+        $expectedJson = '{"book":[{"title":"Foo","year":1991,"links":{"author":1}}],"linked":{"author":[{"id":1,"name":"Dave"}]},"meta":{"foo":"bar"}}';
         $this->assertEquals($expectedJson, $scope->toJson());
     }
 
@@ -192,14 +236,22 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             array(
                 'title' => 'Foo',
                 'year' => '1991',
+                'links' => array(
+                    'author' => 1,
+                ),
                 '_author' => array(
+                    'id' => 1,
                     'name' => 'Dave',
                 ),
             ),
             array(
                 'title' => 'Bar',
                 'year' => '1997',
+                'links' => array(
+                    'author' => 2,
+                ),
                 '_author' => array(
+                    'id' => 2,
                     'name' => 'Bob',
                 ),
             ),
@@ -215,16 +267,28 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                 array(
                     'title' => 'Foo',
                     'year' => 1991,
+                    'links' => array(
+                        'author' => 1,
+                    ),
                 ),
                 array(
                     'title' => 'Bar',
                     'year' => 1997,
+                    'links' => array(
+                        'author' => 2,
+                    ),
                 ),
             ),
             'linked' => array(
                 'author' => array(
-                    array('name' => 'Dave'),
-                    array('name' => 'Bob'),
+                    array(
+                        'id' => 1,
+                        'name' => 'Dave',
+                    ),
+                    array(
+                        'id' => 2,
+                        'name' => 'Bob',
+                    ),
                 ),
             ),
             'meta' => array(
@@ -234,7 +298,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"book":[{"title":"Foo","year":1991},{"title":"Bar","year":1997}],"linked":{"author":[{"name":"Dave"},{"name":"Bob"}]},"meta":{"foo":"bar"}}';
+        $expectedJson = '{"book":[{"title":"Foo","year":1991,"links":{"author":1}},{"title":"Bar","year":1997,"links":{"author":2}}],"linked":{"author":[{"id":1,"name":"Dave"},{"id":2,"name":"Bob"}]},"meta":{"foo":"bar"}}';
         $this->assertEquals($expectedJson, $scope->toJson());
     }
 
@@ -246,6 +310,9 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             array(
                 'title' => 'Foo',
                 'year' => '1991',
+                'links' => array(
+                    'author' => 1,
+                ),
                 '_author' => array(
                     'id' => 1,
                     'name' => 'Dave',
@@ -254,6 +321,9 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             array(
                 'title' => 'Bar',
                 'year' => '1997',
+                'links' => array(
+                    'author' => 1,
+                ),
                 '_author' => array(
                     'id' => 1,
                     'name' => 'Dave',
@@ -269,10 +339,16 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                 array(
                     'title' => 'Foo',
                     'year' => 1991,
+                    'links' => array(
+                        'author' => 1,
+                    ),
                 ),
                 array(
                     'title' => 'Bar',
                     'year' => 1997,
+                    'links' => array(
+                        'author' => 1,
+                    ),
                 ),
             ),
             'linked' => array(
@@ -287,7 +363,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"book":[{"title":"Foo","year":1991},{"title":"Bar","year":1997}],"linked":{"author":[{"id":1,"name":"Dave"}]}}';
+        $expectedJson = '{"book":[{"title":"Foo","year":1991,"links":{"author":1}},{"title":"Bar","year":1997,"links":{"author":1}}],"linked":{"author":[{"id":1,"name":"Dave"}]}}';
         $this->assertEquals($expectedJson, $scope->toJson());
     }
 
@@ -299,6 +375,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             array(
                 'title' => 'Foo',
                 'year' => '1991',
+                'links' => array(
+                    'author' => 1,
+                    'reviews' => array(1),
+                ),
                 '_author' => array(
                     'id' => 1,
                     'name' => 'Dave',
@@ -307,6 +387,9 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     array(
                         'id' => 1,
                         'comment' => 'Foo review',
+                        'links' => array(
+                            'author' => 2,
+                        ),
                         '_author' => array(
                             'id' => 2,
                             'name' => 'Bob',
@@ -317,6 +400,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             array(
                 'title' => 'Bar',
                 'year' => '1997',
+                'links' => array(
+                    'author' => 1,
+                    'reviews' => array(2),
+                ),
                 '_author' => array(
                     'id' => 1,
                     'name' => 'Dave',
@@ -325,6 +412,9 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     array(
                         'id' => 2,
                         'comment' => 'Bar review',
+                        'links' => array(
+                            'author' => 2,
+                        ),
                         '_author' => array(
                             'id' => 2,
                             'name' => 'Bob',
@@ -342,10 +432,18 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                 array(
                     'title' => 'Foo',
                     'year' => 1991,
+                    'links' => array(
+                        'author' => 1,
+                        'reviews' => array(1),
+                    ),
                 ),
                 array(
                     'title' => 'Bar',
                     'year' => 1997,
+                    'links' => array(
+                        'author' => 1,
+                        'reviews' => array(2),
+                    ),
                 ),
             ),
             'linked' => array(
@@ -363,10 +461,16 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     array(
                         'id' => 1,
                         'comment' => 'Foo review',
+                        'links' => array(
+                            'author' => 2,
+                        ),
                     ),
                     array(
                         'id' => 2,
                         'comment' => 'Bar review',
+                        'links' => array(
+                            'author' => 2,
+                        ),
                     ),
                 ),
             ),
@@ -374,7 +478,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"book":[{"title":"Foo","year":1991},{"title":"Bar","year":1997}],"linked":{"author":[{"id":1,"name":"Dave"},{"id":2,"name":"Bob"}],"reviews":[{"id":1,"comment":"Foo review"},{"id":2,"comment":"Bar review"}]}}';
+        $expectedJson = '{"book":[{"title":"Foo","year":1991,"links":{"author":1,"reviews":[1]}},{"title":"Bar","year":1997,"links":{"author":1,"reviews":[2]}}],"linked":{"author":[{"id":1,"name":"Dave"},{"id":2,"name":"Bob"}],"reviews":[{"id":1,"comment":"Foo review","links":{"author":2}},{"id":2,"comment":"Bar review","links":{"author":2}}]}}';
         $this->assertEquals($expectedJson, $scope->toJson());
     }
 

--- a/test/Stub/Transformer/GenericBookTransformer.php
+++ b/test/Stub/Transformer/GenericBookTransformer.php
@@ -6,12 +6,13 @@ class GenericBookTransformer extends TransformerAbstract
 {
     protected $availableIncludes = array(
         'author',
+        'reviews',
     );
 
     public function transform(array $book)
     {
         $book['year'] = (int) $book['year'];
-        unset($book['_author']);
+        unset($book['_author'], $book['_reviews']);
 
         return $book;
     }
@@ -23,5 +24,14 @@ class GenericBookTransformer extends TransformerAbstract
         }
 
         return $this->item($book['_author'], new GenericAuthorTransformer(), 'author');
+    }
+
+    public function includeReviews(array $book)
+    {
+        if (! isset($book['_reviews'])) {
+            return null;
+        }
+
+        return $this->collection($book['_reviews'], new GenericReviewTransformer(), 'reviews');
     }
 }

--- a/test/Stub/Transformer/GenericReviewTransformer.php
+++ b/test/Stub/Transformer/GenericReviewTransformer.php
@@ -1,0 +1,26 @@
+<?php namespace League\Fractal\Test\Stub\Transformer;
+
+use League\Fractal\TransformerAbstract;
+
+class GenericReviewTransformer extends TransformerAbstract
+{
+    protected $availableIncludes = array(
+        'author',
+    );
+
+    public function transform(array $review)
+    {
+        unset($review['_author']);
+
+        return $review;
+    }
+
+    public function includeAuthor(array $review)
+    {
+        if (! isset($review['_author'])) {
+            return null;
+        }
+
+        return $this->item($review['_author'], new GenericAuthorTransformer(), 'author');
+    }
+}


### PR DESCRIPTION
Continuation of https://github.com/thephpleague/fractal/pull/126#issuecomment-63635216

Right now it only includes one level deep of `linked` data.
It is damn hard to have it all, especially when you consider #125 and you no longer have an array of item but a single item.

I think some refactoring would need to be done in order to have it nailed, starting on Manager and Scope.  One depending on each other makes things harder.
The Serializer would need to keep track of included/linked data, from top to bottom, so it can ensure uniqueness. 