### PR TITLE
Correction to pagination query parameters example in documentation

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -57,7 +57,7 @@ $paginatorAdapter = new IlluminatePaginatorAdapter($paginator);
 
 $queryParams = array_diff_key($_GET, array_flip(['page']));
 foreach ($queryParams as $key => $value) {
-	$paginatorAdapter->addQuery($key, $value);
+	$paginator->addQuery($key, $value);
 }
 
 $resource->setPaginator($paginatorAdapter);

--- a/pagination.md
+++ b/pagination.md
@@ -53,13 +53,17 @@ existing query strings. To include all query string values automatically in thes
 the last line above with:
 
 ~~~ php
-$paginatorAdapter = new IlluminatePaginatorAdapter($paginator);
+use Acme\Model\Book;
+
+$year = Input::get('year');
+$paginator = Book::where('year', '=', $year)->paginate(20);
 
 $queryParams = array_diff_key($_GET, array_flip(['page']));
 foreach ($queryParams as $key => $value) {
 	$paginator->addQuery($key, $value);
 }
 
+$paginatorAdapter = new IlluminatePaginatorAdapter($paginator);
 $resource->setPaginator($paginatorAdapter);
 ~~~
 


### PR DESCRIPTION
The `addQuery` method can be found on `Illuminate\Pagination\Paginator` rather than on `League\Fractal\Pagination\IlluminatePaginatorAdapter` as originally suggested in the example.