### PR TITLE
Access includes via getter methods

### DIFF
--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -87,8 +87,8 @@ abstract class TransformerAbstract
      */
     private function figureOutWhichIncludes(Scope $scope)
     {
-        $includes = $this->defaultIncludes;
-        foreach ($this->availableIncludes as $include) {
+        $includes = $this->getDefaultIncludes();
+        foreach ($this->getAvailableIncludes() as $include) {
             if ($scope->isRequested($include)) {
                 $includes[] = $include;
             }


### PR DESCRIPTION
This PR fixes #157.

This PR changes the accessing of the default and available includes to use the getter methods, instead of direct property access. More details as to why this change was made or why it may be important can be found in #157.