### PR TITLE
Move merge of includes to Serializer

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -309,12 +309,7 @@ class Scope
 
         if ($this->transformerHasIncludes($transformer)) {
             $includedData = $this->fireIncludedTransformers($transformer, $data);
-
-            // If the serializer does not want the includes to be side-loaded then
-            // the included data must be merged with the transformed data.
-            if (! $this->manager->getSerializer()->sideloadIncludes()) {
-                $transformedData = array_merge($transformedData, $includedData);
-            }
+            $transformedData = $this->manager->getSerializer()->mergeIncludes($transformedData, $includedData);
         }
 
         return array($transformedData, $includedData);

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -74,6 +74,17 @@ abstract class SerializerAbstract
      */
     abstract public function cursor(CursorInterface $cursor);
 
+    public function mergeIncludes($transformedData, $includedData)
+    {
+        // If the serializer does not want the includes to be side-loaded then
+        // the included data must be merged with the transformed data.
+        if (! $this->sideloadIncludes()) {
+            return array_merge($transformedData, $includedData);
+        }
+
+        return $transformedData;
+    }
+
     /**
      * Indicates if includes should be side-loaded.
      *


### PR DESCRIPTION
This is a simple change that isn't really doing anything by itself, all it does is moving the merge of includes to the Serializer while keeping the current behavior. The point is to give serializers, especially those that side-load includes, a way to customize how includes are merged into the parent scope.

As an example; I was trying to write a EmberSerializer (based on #144), but since the IDs of the side-loaded relations aren't included in the parent scope there's no way for Ember to know which item the side-loaded data is related to. My custom serializer would, without this change, output something like this:

```json
{
  "authors": [
    {
      "id": 1,
      "name": "George R. R. Satan",
    },
    {
      "id": 2,
      "name": "Philip K Dick",
    }
  ],
  "books": [
    {
      "id": 1,
      "name": "Game Of Kill Everyone"
    },
    {
      "id": 2,
      "name": "Game Of Kill Everyone Again"
    },
    {
      "id": 3,
      "name": "Hogfather"
    }
  ]
}
```

By adding a custom `mergeIncludes()` to my serializer I could merge the IDs of my side-loaded includes into the data and thus retain the relationships (which made Ember very happy), like this:

```json
{
  "authors": [
    {
      "id": 1,
      "name": "George R. R. Satan",
      "books": [1, 2]
    },
    {
      "id": 2,
      "name": "Philip K Dick",
      "books": [3]
    }
  ],
  "books": [
    {
      "id": 1,
      "name": "Game Of Kill Everyone"
    },
    {
      "id": 2,
      "name": "Game Of Kill Everyone Again"
    },
    {
      "id": 3,
      "name": "Hogfather"
    }
  ]
}
```

This seemed like a good place and a good way to do this, but if there's a better solution I'm all for it :)