### PR TITLE
Fixed incorrect returntype in docblock for getData method.

### DIFF
--- a/src/Resource/ResourceAbstract.php
+++ b/src/Resource/ResourceAbstract.php
@@ -60,7 +60,7 @@ abstract class ResourceAbstract implements ResourceInterface
     /**
      * Get the data.
      *
-     * @return array|ArrayIterator
+     * @return mixed
      */
     public function getData()
     {

--- a/src/Resource/ResourceInterface.php
+++ b/src/Resource/ResourceInterface.php
@@ -16,7 +16,7 @@ interface ResourceInterface
     /**
      * Get the data.
      *
-     * @return array|ArrayIterator
+     * @return mixed
      */
     public function getData();
 


### PR DESCRIPTION
The types of the getData and setData did not match. Since it seems a perfectly good use case to give for example a string in the setData, getData can also return other types.

For the collection it should only be able to set an array or arrayiIterator. Since no type checking is done throughout the code it makes no sense extending the setData method in Collection only to update its docblock. 