### PR TITLE
Add setMeta to ResourceAbstract

### DIFF
--- a/src/Resource/ResourceAbstract.php
+++ b/src/Resource/ResourceAbstract.php
@@ -138,6 +138,20 @@ abstract class ResourceAbstract implements ResourceInterface
     /**
      * Set the meta data.
      *
+     * @param array $meta
+     *
+     * @return $this
+     */
+    public function setMeta(array $meta)
+    {
+        $this->meta = $meta;
+
+        return $this;
+    }
+
+    /**
+     * Set the meta data.
+     *
      * @param string $metaKey
      * @param mixed  $metaValue
      *

--- a/src/Resource/ResourceAbstract.php
+++ b/src/Resource/ResourceAbstract.php
@@ -131,12 +131,12 @@ abstract class ResourceAbstract implements ResourceInterface
     public function setTransformer($transformer)
     {
         $this->transformer = $transformer;
-        
+
         return $this;
     }
 
     /**
-     * Set the meta data
+     * Set the meta data.
      *
      * @param string $metaKey
      * @param mixed  $metaValue

--- a/test/Resource/CollectionTest.php
+++ b/test/Resource/CollectionTest.php
@@ -93,6 +93,8 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('League\Fractal\Resource\Collection', $collection->setMetaValue('foo', 'bar'));
         $this->assertEquals(array('foo' => 'bar'), $collection->getMeta());
         $this->assertEquals('bar', $collection->getMetaValue('foo'));
+        $collection->setMeta(array('baz' => 'bat'));
+        $this->assertEquals(array('baz' => 'bat'), $collection->getMeta());
     }
 
     /**


### PR DESCRIPTION
The `setMetaValue()` method has a complementary `getMetaValue()`, but `getMeta()` did not have a complementary `setMeta()` method.

This allows a set of meta data to be applied to the resource at once, preventing the need to do something like the following in application code.

```php
foreach ($someMetaData as $metaKey => $metaValue) {
  $theResource->setMetaValue($metaKey, $metaValue);
}
```

I went with overwriting existing meta instead of merging because that's what `setMetaValue()` is doing for individual keys.