### PR TITLE
Method to access setPageName() for Laravel

### DIFF
--- a/src/Pagination/IlluminatePaginatorAdapter.php
+++ b/src/Pagination/IlluminatePaginatorAdapter.php
@@ -103,6 +103,16 @@ class IlluminatePaginatorAdapter implements PaginatorInterface
     }
 
     /**
+     * Set page name variable
+     *
+     * @return void
+     */
+    public function setPageName($pageName)
+    {
+        return $this->paginator->setPageName($pageName);
+    }
+    
+    /**
      * Get the paginator instance.
      *
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator


### PR DESCRIPTION
Sometimes it's necessary to change the page name variable used for pagination. For example, when translating it to a different language. This can be accomplished by the setPageName() method on \Illuminate\Contracts\Pagination\LengthAwarePaginator. Implementing it on Fractal's adapter allows a custom serializer to access this method.