### PR TITLE
Allow param without values

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -168,7 +168,7 @@ class Manager
 
             // Matches multiple instances of 'something(foo|bar|baz)' in the string
             // I guess it ignores : so you could use anything, but probably don't do that
-            preg_match_all('/([\w]+)\(([^\)]+)\)/', $allModifiersStr, $allModifiersArr);
+            preg_match_all('/([\w]+)(\(([^\)]+)\))?/', $allModifiersStr, $allModifiersArr);
 
             // [0] is full matched strings...
             $modifierCount = count($allModifiersArr[0]);
@@ -179,8 +179,8 @@ class Manager
                 // [1] is the modifier
                 $modifierName = $allModifiersArr[1][$modifierIt];
 
-                // and [2] is delimited params
-                $modifierParamStr = $allModifiersArr[2][$modifierIt];
+                // and [3] is delimited params
+                $modifierParamStr = $allModifiersArr[3][$modifierIt];
 
                 // Make modifier array key with an array of params as the value
                 $modifierArr[$modifierName] = explode($this->paramDelimiter, $modifierParamStr);

--- a/test/ManagerTest.php
+++ b/test/ManagerTest.php
@@ -58,7 +58,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo', 'foo.bar'), $manager->getRequestedIncludes());
 
         // See if fancy syntax works
-        $manager->parseIncludes('foo:limit(5|1):order(-something)');
+        $manager->parseIncludes('foo:limit(5|1):order(-something):anotherparam');
 
         $params = $manager->getIncludeParams('foo');
 
@@ -66,6 +66,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('5', '1'), $params['limit']);
         $this->assertEquals(array('-something'), $params['order']);
+        $this->assertEquals(array(''), $params['anotherparam']);
         $this->assertNull($params['totallymadeup']);
     }
 


### PR DESCRIPTION
Actually, with urls like  ````?include=comments:valid```` or ````?include=comments:valid()````, ````valid```` is not concern by parsing of params.

This PR allow it.

My real use case is in fact to have possibility to validate all kind of params (with or without options, and so valid or invalid) from my url whose I have access in my ParamBag