### PR TITLE
Update `JsonApiSerializer` to be compatible with JSON API v1.0

### DIFF
--- a/src/Resource/Null.php
+++ b/src/Resource/Null.php
@@ -1,0 +1,14 @@
+<?php namespace League\Fractal\Resource;
+
+class Null extends ResourceAbstract
+{
+    /**
+     * Get the data.
+     *
+     * @return mixed
+     */
+    public function getData()
+    {
+        return null;
+    }
+}

--- a/src/Resource/NullResource.php
+++ b/src/Resource/NullResource.php
@@ -28,6 +28,6 @@ class NullResource extends ResourceAbstract
      */
     public function getData()
     {
-        return null;
+        // Null has no data associated with it.
     }
 }

--- a/src/Resource/NullResource.php
+++ b/src/Resource/NullResource.php
@@ -1,5 +1,24 @@
-<?php namespace League\Fractal\Resource;
+<?php
 
+/*
+ * This file is part of the League\Fractal package.
+ *
+ * (c) Phil Sturgeon <me@philsturgeon.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\Fractal\Resource;
+
+/**
+ * Null Resource
+ *
+ * The Null Resource represents a resource that doesn't exist. This can be
+ * useful to indicate that a certain relationship is null in some output
+ * formats (e.g. JSON API), which require even a relationship that is null at
+ * the moment to be listed.
+ */
 class NullResource extends ResourceAbstract
 {
     /**

--- a/src/Resource/NullResource.php
+++ b/src/Resource/NullResource.php
@@ -1,6 +1,6 @@
 <?php namespace League\Fractal\Resource;
 
-class Null extends ResourceAbstract
+class NullResource extends ResourceAbstract
 {
     /**
      * Get the data.

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -209,6 +209,15 @@ class Scope
             // about the included resources, it can do so now.
             $data = $serializer->injectData($data, $rawIncludedData);
 
+            if ($this->isRootScope()) {
+                // If the serializer wants to have a final word about all
+                // the objects that are sideloaded, it can do so now.
+                $includedData = $serializer->filterIncludes(
+                    $includedData,
+                    $this->resource
+                );
+            }
+
             $data = array_merge($data, $includedData);
         }
 
@@ -355,5 +364,15 @@ class Scope
         $availableIncludes = $transformer->getAvailableIncludes();
 
         return ! empty($defaultIncludes) || ! empty($availableIncludes);
+    }
+
+    /**
+     * Check, if this is the root scope.
+     *
+     * @return boolean
+     */
+    protected function isRootScope()
+    {
+        return empty($this->parentScopes);
     }
 }

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -14,6 +14,7 @@ namespace League\Fractal;
 use InvalidArgumentException;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
+use League\Fractal\Resource\Null;
 use League\Fractal\Resource\ResourceInterface;
 use League\Fractal\Serializer\SerializerAbstract;
 
@@ -269,6 +270,9 @@ class Scope
             foreach ($data as $value) {
                 list($transformedData[], $includedData[]) = $this->fireTransformer($transformer, $value);
             }
+        } elseif ($this->resource instanceof Null) {
+            $transformedData = null;
+            $includedData = [];
         } else {
             throw new InvalidArgumentException(
                 'Argument $resource should be an instance of League\Fractal\Resource\Item'
@@ -295,8 +299,10 @@ class Scope
 
         if ($this->resource instanceof Collection) {
             return $serializer->collection($resourceKey, $data);
-        } else {
+        } elseif ($this->resource instanceof Item) {
             return $serializer->item($resourceKey, $data);
+        } else {
+            return $serializer->null();
         }
     }
 

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -369,7 +369,7 @@ class Scope
     /**
      * Check, if this is the root scope.
      *
-     * @return boolean
+     * @return bool
      */
     protected function isRootScope()
     {

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -14,7 +14,7 @@ namespace League\Fractal;
 use InvalidArgumentException;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
-use League\Fractal\Resource\Null;
+use League\Fractal\Resource\NullResource;
 use League\Fractal\Resource\ResourceInterface;
 use League\Fractal\Serializer\SerializerAbstract;
 
@@ -270,7 +270,7 @@ class Scope
             foreach ($data as $value) {
                 list($transformedData[], $includedData[]) = $this->fireTransformer($transformer, $value);
             }
-        } elseif ($this->resource instanceof Null) {
+        } elseif ($this->resource instanceof NullResource) {
             $transformedData = null;
             $includedData = [];
         } else {

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -205,6 +205,10 @@ class Scope
         if ($serializer->sideloadIncludes()) {
             $includedData = $serializer->includedData($this->resource, $rawIncludedData);
 
+            // If the serializer wants to inject additional information
+            // about the included resources, it can do so now.
+            $data = $serializer->injectData($data, $rawIncludedData);
+
             $data = array_merge($data, $includedData);
         }
 

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -137,13 +137,16 @@ class JsonApiSerializer extends ArraySerializer
     }
 
     /**
+     * Hook to manipulate the final sideloaded includes.
+     *
      * The JSON API specification does not allow the root object to be included
      * into the sideloaded `included`-array. We have to make sure it is
      * filtered out, in case some object links to the root object in a
      * relationship.
      *
-     * @param  array $includedData
-     * @param  ResourceInterface $resource
+     * @param array             $includedData
+     * @param ResourceInterface $resource
+     *
      * @return array
      */
     public function filterIncludes($includedData, ResourceInterface $resource)
@@ -267,8 +270,9 @@ class JsonApiSerializer extends ArraySerializer
     /**
      * Keep all sideloaded inclusion data on the top level.
      *
-     * @param  ResourceInterface $resource
-     * @param  array             $data
+     * @param ResourceInterface $resource
+     * @param array             $data
+     *
      * @return array
      */
     private function pullOutNestedIncludedData(ResourceInterface $resource, array $data)
@@ -287,10 +291,9 @@ class JsonApiSerializer extends ArraySerializer
     }
 
     /**
-     * Whether or not the serializer should include `links` for resource
-     * objects.
+     * Whether or not the serializer should include `links` for resource objects.
      *
-     * @return boolean
+     * @return bool
      */
     private function shouldIncludeLinks()
     {

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -25,7 +25,13 @@ class JsonApiSerializer extends ArraySerializer
      */
     public function collection($resourceKey, array $data)
     {
-        return array($resourceKey ?: 'data' => $data);
+        $resources = [];
+
+        foreach ($data as $resource) {
+            $resources[] = $this->item($resourceKey, $resource)['data'];
+        }
+
+        return array('data' => $resources);
     }
 
     /**
@@ -38,7 +44,24 @@ class JsonApiSerializer extends ArraySerializer
      */
     public function item($resourceKey, array $data)
     {
-        return array($resourceKey ?: 'data' => array($data));
+        $id = $this->getIdFromData($data);
+
+        $resource = array(
+            'data' => array(
+                'type' => $resourceKey,
+                'id' => "$id",
+                'attributes' => $data,
+            ),
+        );
+
+        if ($id === null) {
+            unset($resource['data']['id']);
+        }
+        else {
+            unset($resource['data']['attributes']['id']);
+        }
+
+        return $resource;
     }
 
     /**
@@ -54,25 +77,17 @@ class JsonApiSerializer extends ArraySerializer
         $serializedData = array();
         $linkedIds = array();
         foreach ($data as $value) {
-            foreach ($value as $includeKey => $includeValue) {
-                foreach ($includeValue[$includeKey] as $itemValue) {
-                    if (!array_key_exists('id', $itemValue)) {
-                        $serializedData[$includeKey][] = $itemValue;
-                        continue;
-                    }
-
-                    $itemId = $itemValue['id'];
-                    if (!empty($linkedIds[$includeKey]) && in_array($itemId, $linkedIds[$includeKey], true)) {
-                        continue;
-                    }
-
-                    $serializedData[$includeKey][] = $itemValue;
-                    $linkedIds[$includeKey][] = $itemId;
+            foreach ($value as $includeKey => $includeObject) {
+                $includeType = $includeObject['data']['type'];
+                $includeId = $includeObject['data']['id'];
+                if (!array_key_exists("$includeType:$includeId", $linkedIds)) {
+                    $serializedData[] = $includeObject['data'];
+                    $linkedIds["$includeType:$includeId"] = $includeObject;
                 }
             }
         }
 
-        return empty($serializedData) ? array() : array('linked' => $serializedData);
+        return empty($serializedData) ? array() : array('included' => $serializedData);
     }
 
     /**
@@ -83,5 +98,71 @@ class JsonApiSerializer extends ArraySerializer
     public function sideloadIncludes()
     {
         return true;
+    }
+
+    public function injectData($data, $includedData)
+    {
+        $relationships = $this->parseRelationships($includedData);
+
+        if (!empty($relationships)) {
+            $data = $this->fillRelationships($data, $relationships);
+        }
+
+        return $data;
+    }
+
+    private function isCollection($data)
+    {
+        return array_key_exists('data', $data) &&
+               array_key_exists(0, $data['data']);
+    }
+
+    private function fillRelationships($data, $relationships)
+    {
+        if ($this->isCollection($data)) {
+            foreach ($relationships as $key => $relationship) {
+                foreach ($relationship as $index => $relationshipData) {
+                    $data['data'][$index]['relationships'][$key] = $relationshipData;
+                }
+            }
+        }
+        else { // Single resource
+            foreach ($relationships as $key => $relationship) {
+                $data['data']['relationships'][$key] = $relationship[0];
+            }
+        }
+
+        return $data;
+    }
+
+    private function parseRelationships($includedData)
+    {
+        $relationships = array();
+
+        foreach ($includedData as $inclusion) {
+            foreach ($inclusion as $includeKey => $includeObject)
+            {
+                if (!array_key_exists($includeKey, $relationships)) {
+                    $relationships[$includeKey] = array();
+                }
+
+                $relationships[$includeKey][] = array(
+                    'data' => array(
+                        'type' => $includeObject['data']['type'],
+                        'id' => $includeObject['data']['id'],
+                    ),
+                );
+            }
+        }
+
+        return $relationships;
+    }
+
+    private function getIdFromData(array $data)
+    {
+        if (!array_key_exists('id', $data)) {
+            return null;
+        }
+        return $data['id'];
     }
 }

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -107,4 +107,16 @@ abstract class SerializerAbstract
     {
         return $data;
     }
+
+    /**
+     * Hook for the serializer to modify the final list of includes.
+     *
+     * @param  array $includedData
+     * @param  ResourceInterface $resource
+     * @return array
+     */
+    public function filterIncludes($includedData, ResourceInterface $resource)
+    {
+        return $includedData;
+    }
 }

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -94,4 +94,17 @@ abstract class SerializerAbstract
     {
         return false;
     }
+
+    /**
+     * Hook for the serializer to inject custom data based on the relationships
+     * of the resource.
+     *
+     * @param  array $data
+     * @param  array $rawIncludedData
+     * @return array
+     */
+    public function injectData($data, $rawIncludedData)
+    {
+        return $data;
+    }
 }

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -96,11 +96,11 @@ abstract class SerializerAbstract
     }
 
     /**
-     * Hook for the serializer to inject custom data based on the relationships
-     * of the resource.
+     * Hook for the serializer to inject custom data based on the relationships of the resource.
      *
-     * @param  array $data
-     * @param  array $rawIncludedData
+     * @param array $data
+     * @param array $rawIncludedData
+     *
      * @return array
      */
     public function injectData($data, $rawIncludedData)
@@ -111,8 +111,9 @@ abstract class SerializerAbstract
     /**
      * Hook for the serializer to modify the final list of includes.
      *
-     * @param  array $includedData
-     * @param  ResourceInterface $resource
+     * @param array             $includedData
+     * @param ResourceInterface $resource
+     *
      * @return array
      */
     public function filterIncludes($includedData, ResourceInterface $resource)

--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -13,7 +13,7 @@ namespace League\Fractal;
 
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
-use League\Fractal\Resource\Null;
+use League\Fractal\Resource\NullResource;
 use League\Fractal\Resource\ResourceAbstract;
 
 /**
@@ -267,10 +267,10 @@ abstract class TransformerAbstract
     /**
      * Create a new null resource object.
      *
-     * @return Null
+     * @return NullResource
      */
     protected function null()
     {
-        return new Null();
+        return new NullResource();
     }
 }

--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -13,6 +13,7 @@ namespace League\Fractal;
 
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
+use League\Fractal\Resource\Null;
 use League\Fractal\Resource\ResourceAbstract;
 
 /**
@@ -261,5 +262,15 @@ abstract class TransformerAbstract
     protected function collection($data, $transformer, $resourceKey = null)
     {
         return new Collection($data, $transformer, $resourceKey);
+    }
+
+    /**
+     * Create a new null resource object.
+     *
+     * @return Null
+     */
+    protected function null()
+    {
+        return new Null();
     }
 }

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -1179,6 +1179,23 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expectedJson, $scope->toJson());
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage JSON API resource objects MUST have a valid id
+     */
+    public function testExceptionThrownIfResourceHasNoId()
+    {
+        $bookData = array(
+            'title' => 'Foo',
+            'year' => '1991',
+        );
+
+        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+
+        $scope = new Scope($this->manager, $resource);
+        $scope->toArray();
+    }
+
     public function tearDown()
     {
         Mockery::close();

--- a/test/Stub/Transformer/JsonApiAuthorTransformer.php
+++ b/test/Stub/Transformer/JsonApiAuthorTransformer.php
@@ -1,0 +1,30 @@
+<?php namespace League\Fractal\Test\Stub\Transformer;
+
+use League\Fractal\TransformerAbstract;
+
+class JsonApiAuthorTransformer extends TransformerAbstract
+{
+    protected $availableIncludes = array(
+        'published',
+    );
+
+    public function transform(array $author)
+    {
+        unset($author['_published']);
+
+        return $author;
+    }
+
+    public function includePublished(array $author)
+    {
+        if (! isset($author['_published'])) {
+            return;
+        }
+
+        return $this->collection(
+            $author['_published'],
+            new JsonApiBookTransformer(),
+            'books'
+        );
+    }
+}

--- a/test/Stub/Transformer/JsonApiBookTransformer.php
+++ b/test/Stub/Transformer/JsonApiBookTransformer.php
@@ -18,8 +18,12 @@ class JsonApiBookTransformer extends TransformerAbstract
 
     public function includeAuthor(array $book)
     {
-        if (! isset($book['_author'])) {
+        if (!array_key_exists('_author', $book)) {
             return;
+        }
+
+        if ($book['_author'] === null) {
+            return $this->null();
         }
 
         return $this->item($book['_author'], new JsonApiAuthorTransformer(), 'people');

--- a/test/Stub/Transformer/JsonApiBookTransformer.php
+++ b/test/Stub/Transformer/JsonApiBookTransformer.php
@@ -1,0 +1,27 @@
+<?php namespace League\Fractal\Test\Stub\Transformer;
+
+use League\Fractal\TransformerAbstract;
+
+class JsonApiBookTransformer extends TransformerAbstract
+{
+    protected $availableIncludes = array(
+        'author',
+    );
+
+    public function transform(array $book)
+    {
+        $book['year'] = (int) $book['year'];
+        unset($book['_author']);
+
+        return $book;
+    }
+
+    public function includeAuthor(array $book)
+    {
+        if (! isset($book['_author'])) {
+            return;
+        }
+
+        return $this->item($book['_author'], new GenericAuthorTransformer(), 'people');
+    }
+}

--- a/test/Stub/Transformer/JsonApiBookTransformer.php
+++ b/test/Stub/Transformer/JsonApiBookTransformer.php
@@ -22,6 +22,6 @@ class JsonApiBookTransformer extends TransformerAbstract
             return;
         }
 
-        return $this->item($book['_author'], new GenericAuthorTransformer(), 'people');
+        return $this->item($book['_author'], new JsonApiAuthorTransformer(), 'people');
     }
 }


### PR DESCRIPTION
I am using fractal for my API responses, which is consumed by an Ember app and want to have a Serializer that converts to JSON API v1.0 (which will be the default in Ember's future).

I took a stab at the TODOs listed in #187:

> What we need to do:
>
> - [x] Add links
> - [x] Add relationships
>     - [x] to-one
>     - [x] to-many
>     - [x] nested relationships
>     - [x] empty relationships
> - [x] Always set data as resource key
> - [x] Rename includes to included
> - [x] Included resources should be moved outside the data object
> - [x] All resources should return id, type and attributes

Additional things to do:
 - [x] Write documentation for the new serializer

I will try to add the remaining TODOs over this weekend.

Please provide feedback and mention any other things we need to get done before we can implement JSON APIs with fractal.

Cheers