### PR TITLE
Fix: Use short array syntax

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -29,14 +29,14 @@ class Manager
      *
      * @var array
      */
-    protected $requestedIncludes = array();
+    protected $requestedIncludes = [];
 
     /**
      * Array containing modifiers as keys and an array value of params.
      *
      * @var array
      */
-    protected $includeParams = array();
+    protected $includeParams = [];
 
     /**
      * The character used to separate modifier parameters.
@@ -138,7 +138,7 @@ class Manager
     public function parseIncludes($includes)
     {
         // Wipe these before we go again
-        $this->requestedIncludes = $this->includeParams = array();
+        $this->requestedIncludes = $this->includeParams = [];
 
         if (is_string($includes)) {
             $includes = explode(',', $includes);
@@ -173,7 +173,7 @@ class Manager
             // [0] is full matched strings...
             $modifierCount = count($allModifiersArr[0]);
 
-            $modifierArr = array();
+            $modifierArr = [];
 
             for ($modifierIt = 0; $modifierIt < $modifierCount; $modifierIt++) {
                 // [1] is the modifier
@@ -235,7 +235,7 @@ class Manager
      */
     protected function autoIncludeParents()
     {
-        $parsed = array();
+        $parsed = [];
 
         foreach ($this->requestedIncludes as $include) {
             $nested = explode('.', $include);

--- a/src/ParamBag.php
+++ b/src/ParamBag.php
@@ -19,7 +19,7 @@ class ParamBag implements \ArrayAccess, \IteratorAggregate
     /**
      * @var array
      */
-    protected $params = array();
+    protected $params = [];
 
     /**
      * Create a new parameter bag instance.

--- a/src/Resource/ResourceAbstract.php
+++ b/src/Resource/ResourceAbstract.php
@@ -25,7 +25,7 @@ abstract class ResourceAbstract implements ResourceInterface
      *
      * @var array
      */
-    protected $meta = array();
+    protected $meta = [];
 
     /**
      * The resource key.

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -30,7 +30,7 @@ class Scope
     /**
      * @var array
      */
-    protected $availableIncludes = array();
+    protected $availableIncludes = [];
 
     /**
      * @var string
@@ -50,7 +50,7 @@ class Scope
     /**
      * @var array
      */
-    protected $parentScopes = array();
+    protected $parentScopes = [];
 
     /**
      * Create a new scope instance.
@@ -102,7 +102,7 @@ class Scope
      */
     public function getIdentifier($appendIdentifier = null)
     {
-        $identifierParts = array_merge($this->parentScopes, array($this->scopeIdentifier, $appendIdentifier));
+        $identifierParts = array_merge($this->parentScopes, [$this->scopeIdentifier, $appendIdentifier]);
 
         return implode('.', array_filter($identifierParts));
     }
@@ -156,7 +156,7 @@ class Scope
             $scopeArray = array_slice($this->parentScopes, 1);
             array_push($scopeArray, $this->scopeIdentifier, $checkScopeSegment);
         } else {
-            $scopeArray = array($checkScopeSegment);
+            $scopeArray = [$checkScopeSegment];
         }
 
         $scopeString = implode('.', (array) $scopeArray);
@@ -272,7 +272,7 @@ class Scope
         $transformer = $this->resource->getTransformer();
         $data = $this->resource->getData();
 
-        $transformedData = $includedData = array();
+        $transformedData = $includedData = [];
 
         if ($this->resource instanceof Item) {
             list($transformedData, $includedData[]) = $this->fireTransformer($transformer, $data);
@@ -290,7 +290,7 @@ class Scope
             );
         }
 
-        return array($transformedData, $includedData);
+        return [$transformedData, $includedData];
     }
 
     /**
@@ -330,7 +330,7 @@ class Scope
      */
     protected function fireTransformer($transformer, $data)
     {
-        $includedData = array();
+        $includedData = [];
 
         if (is_callable($transformer)) {
             $transformedData = call_user_func($transformer, $data);
@@ -343,7 +343,7 @@ class Scope
             $transformedData = $this->manager->getSerializer()->mergeIncludes($transformedData, $includedData);
         }
 
-        return array($transformedData, $includedData);
+        return [$transformedData, $includedData];
     }
 
     /**
@@ -360,7 +360,7 @@ class Scope
     {
         $this->availableIncludes = $transformer->getAvailableIncludes();
 
-        return $transformer->processIncludedResources($this, $data) ?: array();
+        return $transformer->processIncludedResources($this, $data) ?: [];
     }
 
     /**

--- a/src/Serializer/ArraySerializer.php
+++ b/src/Serializer/ArraySerializer.php
@@ -27,7 +27,7 @@ class ArraySerializer extends SerializerAbstract
      */
     public function collection($resourceKey, array $data)
     {
-        return array($resourceKey ?: 'data' => $data);
+        return [$resourceKey ?: 'data' => $data];
     }
 
     /**
@@ -66,10 +66,10 @@ class ArraySerializer extends SerializerAbstract
     public function meta(array $meta)
     {
         if (empty($meta)) {
-            return array();
+            return [];
         }
 
-        return array('meta' => $meta);
+        return ['meta' => $meta];
     }
 
     /**
@@ -84,15 +84,15 @@ class ArraySerializer extends SerializerAbstract
         $currentPage = (int) $paginator->getCurrentPage();
         $lastPage = (int) $paginator->getLastPage();
 
-        $pagination = array(
+        $pagination = [
             'total' => (int) $paginator->getTotal(),
             'count' => (int) $paginator->getCount(),
             'per_page' => (int) $paginator->getPerPage(),
             'current_page' => $currentPage,
             'total_pages' => $lastPage,
-        );
+        ];
 
-        $pagination['links'] = array();
+        $pagination['links'] = [];
 
         if ($currentPage > 1) {
             $pagination['links']['previous'] = $paginator->getUrl($currentPage - 1);
@@ -102,7 +102,7 @@ class ArraySerializer extends SerializerAbstract
             $pagination['links']['next'] = $paginator->getUrl($currentPage + 1);
         }
 
-        return array('pagination' => $pagination);
+        return ['pagination' => $pagination];
     }
 
     /**
@@ -114,13 +114,13 @@ class ArraySerializer extends SerializerAbstract
      */
     public function cursor(CursorInterface $cursor)
     {
-        $cursor = array(
+        $cursor = [
             'current' => $cursor->getCurrent(),
             'prev' => $cursor->getPrev(),
             'next' => $cursor->getNext(),
             'count' => (int) $cursor->getCount(),
-        );
+        ];
 
-        return array('cursor' => $cursor);
+        return ['cursor' => $cursor];
     }
 }

--- a/src/Serializer/DataArraySerializer.php
+++ b/src/Serializer/DataArraySerializer.php
@@ -23,7 +23,7 @@ class DataArraySerializer extends ArraySerializer
      */
     public function collection($resourceKey, array $data)
     {
-        return array('data' => $data);
+        return ['data' => $data];
     }
 
     /**
@@ -36,6 +36,6 @@ class DataArraySerializer extends ArraySerializer
      */
     public function item($resourceKey, array $data)
     {
-        return array('data' => $data);
+        return ['data' => $data];
     }
 }

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -42,7 +42,7 @@ class JsonApiSerializer extends ArraySerializer
             $resources[] = $this->item($resourceKey, $resource)['data'];
         }
 
-        return array('data' => $resources);
+        return ['data' => $resources];
     }
 
     /**
@@ -57,20 +57,20 @@ class JsonApiSerializer extends ArraySerializer
     {
         $id = $this->getIdFromData($data);
 
-        $resource = array(
-            'data' => array(
+        $resource = [
+            'data' => [
                 'type' => $resourceKey,
                 'id' => "$id",
                 'attributes' => $data,
-            ),
-        );
+            ],
+        ];
 
         unset($resource['data']['attributes']['id']);
 
         if ($this->shouldIncludeLinks()) {
-            $resource['data']['links'] = array(
+            $resource['data']['links'] = [
                 'self' => "{$this->baseUrl}/$resourceKey/$id",
-            );
+            ];
         }
 
         return $resource;
@@ -78,9 +78,9 @@ class JsonApiSerializer extends ArraySerializer
 
     public function null()
     {
-        return array(
+        return [
             'data' => null,
-        );
+        ];
     }
 
     /**
@@ -107,7 +107,7 @@ class JsonApiSerializer extends ArraySerializer
                     $includeObjects = $includeObject['data'];
                 }
                 else {
-                    $includeObjects = array($includeObject['data']);
+                    $includeObjects = [$includeObject['data']];
                 }
 
                 foreach ($includeObjects as $object) {
@@ -122,7 +122,7 @@ class JsonApiSerializer extends ArraySerializer
             }
         }
 
-        return empty($serializedData) ? array() : array('included' => $serializedData);
+        return empty($serializedData) ? [] : ['included' => $serializedData];
     }
 
     /**
@@ -176,7 +176,7 @@ class JsonApiSerializer extends ArraySerializer
         $filteredIncludes = array_filter($includedData['included'], [$this, 'filterRootObject']);
 
         // Reset array indizes
-        $includedData['included'] = array_merge(array(), $filteredIncludes);
+        $includedData['included'] = array_merge([], $filteredIncludes);
 
         return $includedData;
     }
@@ -198,7 +198,7 @@ class JsonApiSerializer extends ArraySerializer
      *
      * @param array $objects
      */
-    private function setRootObjects(array $objects = array())
+    private function setRootObjects(array $objects = [])
     {
         $this->rootObjects = array_map(function($object) {
             return "{$object['type']}:{$object['id']}";
@@ -230,7 +230,7 @@ class JsonApiSerializer extends ArraySerializer
     }
 
     private function isEmpty($data) {
-        return array_key_exists('data', $data) && $data['data'] === array();
+        return array_key_exists('data', $data) && $data['data'] === [];
     }
 
     private function fillRelationships($data, $relationships)
@@ -247,12 +247,12 @@ class JsonApiSerializer extends ArraySerializer
                 $data['data']['relationships'][$key] = $relationship[0];
 
                 if ($this->shouldIncludeLinks()) {
-                    $data['data']['relationships'][$key] = array_merge(array(
-                        'links' => array(
+                    $data['data']['relationships'][$key] = array_merge([
+                        'links' => [
                             'self' => "{$this->baseUrl}/{$data['data']['type']}/{$data['data']['id']}/relationships/$key",
                             'related' => "{$this->baseUrl}/{$data['data']['type']}/{$data['data']['id']}/$key",
-                        ),
-                    ), $data['data']['relationships'][$key]);
+                        ],
+                    ], $data['data']['relationships'][$key]);
                 }
             }
         }
@@ -262,40 +262,40 @@ class JsonApiSerializer extends ArraySerializer
 
     private function parseRelationships($includedData)
     {
-        $relationships = array();
+        $relationships = [];
 
         foreach ($includedData as $inclusion) {
             foreach ($inclusion as $includeKey => $includeObject)
             {
                 if (!array_key_exists($includeKey, $relationships)) {
-                    $relationships[$includeKey] = array();
+                    $relationships[$includeKey] = [];
                 }
 
                 if ($this->isNull($includeObject)) {
                     $relationship = $this->null();
                 }
                 elseif ($this->isEmpty($includeObject)) {
-                    $relationship = array(
-                        'data' => array(),
-                    );
+                    $relationship = [
+                        'data' => [],
+                    ];
                 }
                 elseif ($this->isCollection($includeObject)) {
-                    $relationship = array('data' => array());
+                    $relationship = ['data' => []];
 
                     foreach ($includeObject['data'] as $object) {
-                        $relationship['data'][] = array(
+                        $relationship['data'][] = [
                             'type' => $object['type'],
                             'id' => $object['id'],
-                        );
+                        ];
                     }
                 }
                 else {
-                    $relationship = array(
-                        'data' => array(
+                    $relationship = [
+                        'data' => [
                             'type' => $includeObject['data']['type'],
                             'id' => $includeObject['data']['id'],
-                        ),
-                    );
+                        ],
+                    ];
                 }
 
                 $relationships[$includeKey][] = $relationship;
@@ -325,8 +325,8 @@ class JsonApiSerializer extends ArraySerializer
      */
     private function pullOutNestedIncludedData(ResourceInterface $resource, array $data)
     {
-        $includedData = array();
-        $linkedIds = array();
+        $includedData = [];
+        $linkedIds = [];
 
         foreach ($data as $value) {
             foreach ($value as $includeKey => $includeObject) {
@@ -345,7 +345,7 @@ class JsonApiSerializer extends ArraySerializer
             }
         }
 
-        return array($includedData, $linkedIds);
+        return [$includedData, $linkedIds];
     }
 
     /**

--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -31,14 +31,14 @@ abstract class TransformerAbstract
      *
      * @var array
      */
-    protected $availableIncludes = array();
+    protected $availableIncludes = [];
 
     /**
      * Include resources without needing it to be requested.
      *
      * @var array
      */
-    protected $defaultIncludes = array();
+    protected $defaultIncludes = [];
 
     /**
      * The transformer should know about the current scope, so we can fetch relevant params.
@@ -111,7 +111,7 @@ abstract class TransformerAbstract
      */
     public function processIncludedResources(Scope $scope, $data)
     {
-        $includedData = array();
+        $includedData = [];
 
         $includes = $this->figureOutWhichIncludes($scope);
 
@@ -124,7 +124,7 @@ abstract class TransformerAbstract
             );
         }
 
-        return $includedData === array() ? false : $includedData;
+        return $includedData === [] ? false : $includedData;
     }
 
     /**
@@ -175,7 +175,7 @@ abstract class TransformerAbstract
         // Check if the method name actually exists
         $methodName = 'include'.str_replace(' ', '', ucwords(str_replace('_', ' ', $includeName)));
 
-        $resource = call_user_func(array($this, $methodName), $data, $params);
+        $resource = call_user_func([$this, $methodName], $data, $params);
 
         if ($resource === null) {
             return false;

--- a/test/ManagerTest.php
+++ b/test/ManagerTest.php
@@ -12,7 +12,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $manager = new Manager();
 
         // Test that some includes provided returns self
-        $this->assertInstanceOf(get_class($manager), $manager->parseIncludes(array('foo')));
+        $this->assertInstanceOf(get_class($manager), $manager->parseIncludes(['foo']));
     }
 
     /**
@@ -43,19 +43,19 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         // Does a CSV string work
         $manager->parseIncludes('foo,bar');
-        $this->assertEquals(array('foo', 'bar'), $manager->getRequestedIncludes());
+        $this->assertEquals(['foo', 'bar'], $manager->getRequestedIncludes());
 
         // Does a big array of stuff work
-        $manager->parseIncludes(array('foo', 'bar', 'bar.baz'));
-        $this->assertEquals(array('foo', 'bar', 'bar.baz'), $manager->getRequestedIncludes());
+        $manager->parseIncludes(['foo', 'bar', 'bar.baz']);
+        $this->assertEquals(['foo', 'bar', 'bar.baz'], $manager->getRequestedIncludes());
 
         // Are repeated things stripped
-        $manager->parseIncludes(array('foo', 'foo', 'bar'));
-        $this->assertEquals(array('foo', 'bar'), $manager->getRequestedIncludes());
+        $manager->parseIncludes(['foo', 'foo', 'bar']);
+        $this->assertEquals(['foo', 'bar'], $manager->getRequestedIncludes());
 
         // Do requests for `baz.bart` also request `baz`?
-        $manager->parseIncludes(array('foo.bar'));
-        $this->assertEquals(array('foo', 'foo.bar'), $manager->getRequestedIncludes());
+        $manager->parseIncludes(['foo.bar']);
+        $this->assertEquals(['foo', 'foo.bar'], $manager->getRequestedIncludes());
 
         // See if fancy syntax works
         $manager->parseIncludes('foo:limit(5|1):order(-something):anotherparam');
@@ -64,9 +64,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('League\Fractal\ParamBag', $params);
 
-        $this->assertEquals(array('5', '1'), $params['limit']);
-        $this->assertEquals(array('-something'), $params['order']);
-        $this->assertEquals(array(''), $params['anotherparam']);
+        $this->assertEquals(['5', '1'], $params['limit']);
+        $this->assertEquals(['-something'], $params['order']);
+        $this->assertEquals([''], $params['anotherparam']);
         $this->assertNull($params['totallymadeup']);
     }
 
@@ -77,7 +77,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         // Should limit to 10 by default
         $manager->parseIncludes('a.b.c.d.e.f.g.h.i.j.NEVER');
         $this->assertEquals(
-            array(
+            [
                 'a',
                 'a.b',
                 'a.b.c',
@@ -88,7 +88,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                 'a.b.c.d.e.f.g.h',
                 'a.b.c.d.e.f.g.h.i',
                 'a.b.c.d.e.f.g.h.i.j',
-            ),
+            ],
             $manager->getRequestedIncludes()
         );
 
@@ -96,11 +96,11 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $manager->setRecursionLimit(3);
         $manager->parseIncludes('a.b.c.NEVER');
         $this->assertEquals(
-            array(
+            [
                 'a',
                 'a.b',
                 'a.b.c',
-            ),
+            ],
             $manager->getRequestedIncludes()
         );
     }
@@ -110,7 +110,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $manager = new Manager();
 
         // Item
-        $resource = new Item(array('foo' => 'bar'), function (array $data) {
+        $resource = new Item(['foo' => 'bar'], function (array $data) {
             return $data;
         });
 
@@ -118,11 +118,11 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('League\Fractal\Scope', $rootScope);
 
-        $this->assertEquals(array('data' => array('foo' => 'bar')), $rootScope->toArray());
+        $this->assertEquals(['data' => ['foo' => 'bar']], $rootScope->toArray());
         $this->assertEquals('{"data":{"foo":"bar"}}', $rootScope->toJson());
 
         // Collection
-        $resource = new Collection(array(array('foo' => 'bar')), function (array $data) {
+        $resource = new Collection([['foo' => 'bar']], function (array $data) {
             return $data;
         });
 
@@ -130,7 +130,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('League\Fractal\Scope', $rootScope);
 
-        $this->assertEquals(array('data' => array(array('foo' => 'bar'))), $rootScope->toArray());
+        $this->assertEquals(['data' => [['foo' => 'bar']]], $rootScope->toArray());
         $this->assertEquals('{"data":[{"foo":"bar"}]}', $rootScope->toJson());
     }
 

--- a/test/Pagination/PagerfantaPaginatorAdapterTest.php
+++ b/test/Pagination/PagerfantaPaginatorAdapterTest.php
@@ -8,15 +8,15 @@ class PagerfantaPaginatorAdapterTest extends \PHPUnit_Framework_TestCase
 {
     public function testPaginationAdapter()
     {
-        $items = array(
+        $items = [
             'Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5', 'Item 6', 'Item 7', 'Item 8', 'Item 9', 'Item 10',
             'Item 11', 'Item 12', 'Item 13', 'Item 14', 'Item 15', 'Item 16', 'Item 17', 'Item 18', 'Item 19', 'Item 20',
             'Item 21', 'Item 22', 'Item 23', 'Item 24', 'Item 25', 'Item 26', 'Item 27', 'Item 28', 'Item 29', 'Item 30',
             'Item 31', 'Item 32', 'Item 33', 'Item 34', 'Item 35', 'Item 36', 'Item 37', 'Item 38', 'Item 39', 'Item 40',
             'Item 41', 'Item 42', 'Item 43', 'Item 44', 'Item 45', 'Item 46', 'Item 47', 'Item 48', 'Item 49', 'Item 50',
-        );
+        ];
 
-        $adapter = Mockery::mock('Pagerfanta\Adapter\ArrayAdapter', array($items))->makePartial();
+        $adapter = Mockery::mock('Pagerfanta\Adapter\ArrayAdapter', [$items])->makePartial();
 
         $total       = 50;
         $count       = 5;
@@ -24,7 +24,7 @@ class PagerfantaPaginatorAdapterTest extends \PHPUnit_Framework_TestCase
         $currentPage = 2;
         $lastPage    = 10;
 
-        $paginator = Mockery::mock('Pagerfanta\Pagerfanta', array($adapter))->makePartial();
+        $paginator = Mockery::mock('Pagerfanta\Pagerfanta', [$adapter])->makePartial();
 
         $paginator->shouldReceive('getCurrentPage')->andReturn($currentPage);
         $paginator->shouldReceive('getLastPage')->andReturn($lastPage);

--- a/test/Pagination/ZendFrameworkPaginatorAdapterTest.php
+++ b/test/Pagination/ZendFrameworkPaginatorAdapterTest.php
@@ -8,15 +8,15 @@ class ZendFrameworkPaginatorAdapterTest extends \PHPUnit_Framework_TestCase
 {
     public function testPaginationAdapter()
     {
-        $items = array(
+        $items = [
             'Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5', 'Item 6', 'Item 7', 'Item 8', 'Item 9', 'Item 10',
             'Item 11', 'Item 12', 'Item 13', 'Item 14', 'Item 15', 'Item 16', 'Item 17', 'Item 18', 'Item 19', 'Item 20',
             'Item 21', 'Item 22', 'Item 23', 'Item 24', 'Item 25', 'Item 26', 'Item 27', 'Item 28', 'Item 29', 'Item 30',
             'Item 31', 'Item 32', 'Item 33', 'Item 34', 'Item 35', 'Item 36', 'Item 37', 'Item 38', 'Item 39', 'Item 40',
             'Item 41', 'Item 42', 'Item 43', 'Item 44', 'Item 45', 'Item 46', 'Item 47', 'Item 48', 'Item 49', 'Item 50',
-        );
+        ];
 
-        $adapter = Mockery::mock('Zend\Paginator\Adapter\ArrayAdapter', array($items))->makePartial();
+        $adapter = Mockery::mock('Zend\Paginator\Adapter\ArrayAdapter', [$items])->makePartial();
 
         $total = 50;
         $count = 10;
@@ -24,7 +24,7 @@ class ZendFrameworkPaginatorAdapterTest extends \PHPUnit_Framework_TestCase
         $currentPage = 2;
         $lastPage = 5;
 
-        $paginator = Mockery::mock('Zend\Paginator\Paginator', array($adapter))->makePartial();
+        $paginator = Mockery::mock('Zend\Paginator\Paginator', [$adapter])->makePartial();
 
         $paginator->shouldReceive('getCurrentPageNumber')->andReturn($currentPage);
         $paginator->shouldReceive('count')->andReturn($lastPage);

--- a/test/ParamBagTest.php
+++ b/test/ParamBagTest.php
@@ -6,7 +6,7 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
 {
     public function testOldFashionedGet()
     {
-        $params = new ParamBag(array('one' => 'potato', 'two' => 'potato2'));
+        $params = new ParamBag(['one' => 'potato', 'two' => 'potato2']);
 
         $this->assertEquals('potato', $params->get('one'));
         $this->assertEquals('potato2', $params->get('two'));
@@ -14,14 +14,14 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
 
     public function testGettingValuesTheOldFashionedWayArray()
     {
-        $params = new ParamBag(array('one' => array('potato', 'tomato')));
+        $params = new ParamBag(['one' => ['potato', 'tomato']]);
 
-        $this->assertEquals(array('potato', 'tomato'), $params->get('one'));
+        $this->assertEquals(['potato', 'tomato'], $params->get('one'));
     }
 
     public function testArrayAccess()
     {
-        $params = new ParamBag(array('foo' => 'bar', 'baz' => 'ban'));
+        $params = new ParamBag(['foo' => 'bar', 'baz' => 'ban']);
 
         $this->assertInstanceOf('ArrayAccess', $params);
         $this->assertArrayHasKey('foo', $params);
@@ -37,7 +37,7 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
      */
     public function testArrayAccessSetFails()
     {
-        $params = new ParamBag(array('foo' => 'bar'));
+        $params = new ParamBag(['foo' => 'bar']);
 
         $params['foo'] = 'someothervalue';
     }
@@ -48,14 +48,14 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
      */
     public function testArrayAccessUnsetFails()
     {
-        $params = new ParamBag(array('foo' => 'bar'));
+        $params = new ParamBag(['foo' => 'bar']);
 
         unset($params['foo']);
     }
 
     public function testObjectAccess()
     {
-        $params = new ParamBag(array('foo' => 'bar', 'baz' => 'ban'));
+        $params = new ParamBag(['foo' => 'bar', 'baz' => 'ban']);
 
         $this->assertEquals('bar', $params->foo);
         $this->assertEquals('ban', $params->baz);
@@ -69,7 +69,7 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
      */
     public function testObjectAccessSetFails()
     {
-        $params = new ParamBag(array('foo' => 'bar'));
+        $params = new ParamBag(['foo' => 'bar']);
 
         $params->foo = 'someothervalue';
     }
@@ -80,7 +80,7 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
      */
     public function testObjectAccessUnsetFails()
     {
-        $params = new ParamBag(array('foo' => 'bar'));
+        $params = new ParamBag(['foo' => 'bar']);
 
         unset($params->foo);
     }

--- a/test/Resource/CollectionTest.php
+++ b/test/Resource/CollectionTest.php
@@ -6,10 +6,10 @@ use Mockery;
 
 class CollectionTest extends \PHPUnit_Framework_TestCase
 {
-    protected $simpleCollection = array(
-        array('foo' => 'bar'),
-        array('baz' => 'ban'),
-    );
+    protected $simpleCollection = [
+        ['foo' => 'bar'],
+        ['baz' => 'ban'],
+    ];
 
     public function testGetData()
     {
@@ -91,10 +91,10 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = Mockery::mock('League\Fractal\Resource\Collection')->makePartial();
         $this->assertInstanceOf('League\Fractal\Resource\Collection', $collection->setMetaValue('foo', 'bar'));
-        $this->assertEquals(array('foo' => 'bar'), $collection->getMeta());
+        $this->assertEquals(['foo' => 'bar'], $collection->getMeta());
         $this->assertEquals('bar', $collection->getMetaValue('foo'));
-        $collection->setMeta(array('baz' => 'bat'));
-        $this->assertEquals(array('baz' => 'bat'), $collection->getMeta());
+        $collection->setMeta(['baz' => 'bat']);
+        $this->assertEquals(['baz' => 'bat'], $collection->getMeta());
     }
 
     /**

--- a/test/Resource/ItemTest.php
+++ b/test/Resource/ItemTest.php
@@ -5,7 +5,7 @@ use Mockery;
 
 class ItemTest extends \PHPUnit_Framework_TestCase
 {
-    protected $simpleItem = array('foo' => 'bar');
+    protected $simpleItem = ['foo' => 'bar'];
 
     public function testGetData()
     {

--- a/test/ScopeTest.php
+++ b/test/ScopeTest.php
@@ -11,14 +11,14 @@ use Mockery;
 
 class ScopeTest extends \PHPUnit_Framework_TestCase
 {
-    protected $simpleItem = array('foo' => 'bar');
-    protected $simpleCollection = array(array('foo' => 'bar'));
+    protected $simpleItem = ['foo' => 'bar'];
+    protected $simpleCollection = [['foo' => 'bar']];
 
     public function testEmbedChildScope()
     {
         $manager = new Manager();
 
-        $resource = new Item(array('foo' => 'bar'), function () {
+        $resource = new Item(['foo' => 'bar'], function () {
         });
 
         $scope = new Scope($manager, $resource, 'book');
@@ -30,7 +30,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
     public function testGetManager()
     {
-        $resource = new Item(array('foo' => 'bar'), function () {
+        $resource = new Item(['foo' => 'bar'], function () {
         });
 
         $scope = new Scope(new Manager(), $resource, 'book');
@@ -40,7 +40,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
     public function testGetResource()
     {
-        $resource = new Item(array('foo' => 'bar'), function () {
+        $resource = new Item(['foo' => 'bar'], function () {
         });
 
         $scope = new Scope(new Manager(), $resource, 'book');
@@ -56,13 +56,13 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     {
         $manager = new Manager();
 
-        $resource = new Item(array('foo' => 'bar'), function ($data) {
+        $resource = new Item(['foo' => 'bar'], function ($data) {
             return $data;
         });
 
         $scope = new Scope($manager, $resource);
 
-        $this->assertEquals(array('data' => array('foo' => 'bar')), $scope->toArray());
+        $this->assertEquals(['data' => ['foo' => 'bar']], $scope->toArray());
     }
 
     public function testToJson()
@@ -90,7 +90,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     {
         $manager = new Manager();
 
-        $resource = new Item(array('name' => 'Larry Ullman'), function () {
+        $resource = new Item(['name' => 'Larry Ullman'], function () {
         });
 
         $scope = new Scope($manager, $resource, 'book');
@@ -107,7 +107,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     {
         $manager = new Manager();
 
-        $resource = new Item(array('name' => 'Larry Ullman'), function () {
+        $resource = new Item(['name' => 'Larry Ullman'], function () {
         });
 
         $scope = new Scope($manager, $resource, 'book');
@@ -124,22 +124,22 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     {
         $manager = new Manager();
 
-        $resource = new Item(array('name' => 'Larry Ullman'), function () {
+        $resource = new Item(['name' => 'Larry Ullman'], function () {
         });
 
         $scope = new Scope($manager, $resource, 'book');
 
         $childScope = $scope->embedChildScope('author', $resource);
-        $this->assertEquals(array('book'), $childScope->getParentScopes());
+        $this->assertEquals(['book'], $childScope->getParentScopes());
 
         $grandChildScope = $childScope->embedChildScope('profile', $resource);
-        $this->assertEquals(array('book', 'author'), $grandChildScope->getParentScopes());
+        $this->assertEquals(['book', 'author'], $grandChildScope->getParentScopes());
     }
 
     public function testIsRequested()
     {
         $manager = new Manager();
-        $manager->parseIncludes(array('foo', 'bar', 'baz.bart'));
+        $manager->parseIncludes(['foo', 'bar', 'baz.bart']);
 
         $scope = new Scope($manager, Mockery::mock('League\Fractal\Resource\ResourceAbstract'));
 
@@ -164,10 +164,10 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $manager = new Manager();
         $manager->parseIncludes('book');
 
-        $resource = Mockery::mock('League\Fractal\Resource\ResourceAbstract', array(
-            array('bar' => 'baz'),
+        $resource = Mockery::mock('League\Fractal\Resource\ResourceAbstract', [
+            ['bar' => 'baz'],
             function () {},
-        ))->makePartial();
+        ])->makePartial();
 
         $scope = new Scope($manager, $resource);
         $scope->toArray();
@@ -179,17 +179,17 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $manager->parseIncludes('book');
 
         $transformer = Mockery::mock('League\Fractal\TransformerAbstract')->makePartial();
-        $transformer->shouldReceive('getAvailableIncludes')->twice()->andReturn(array('book'));
+        $transformer->shouldReceive('getAvailableIncludes')->twice()->andReturn(['book']);
         $transformer->shouldReceive('transform')->once()->andReturnUsing(function (array $data) {
             return $data;
         });
-        $transformer->shouldReceive('processIncludedResources')->once()->andReturn(array('book' => array('yin' => 'yang')));
+        $transformer->shouldReceive('processIncludedResources')->once()->andReturn(['book' => ['yin' => 'yang']]);
 
-        $resource = new Item(array('bar' => 'baz'), $transformer);
+        $resource = new Item(['bar' => 'baz'], $transformer);
 
         $scope = new Scope($manager, $resource);
 
-        $this->assertEquals(array('data' => array('bar' => 'baz', 'book' => array('yin' => 'yang'))), $scope->toArray());
+        $this->assertEquals(['data' => ['bar' => 'baz', 'book' => ['yin' => 'yang']]], $scope->toArray());
     }
 
     public function testToArrayWithSideloadedIncludes()
@@ -197,10 +197,10 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $serializer = Mockery::mock('League\Fractal\Serializer\ArraySerializer')->makePartial();
         $serializer->shouldReceive('sideloadIncludes')->andReturn(true);
         $serializer->shouldReceive('item')->andReturnUsing(function ($key, $data) {
-            return array('data' => $data);
+            return ['data' => $data];
         });
         $serializer->shouldReceive('includedData')->andReturnUsing(function ($key, $data) {
-            return array('sideloaded' => array_pop($data));
+            return ['sideloaded' => array_pop($data)];
         });
 
         $manager = new Manager();
@@ -208,20 +208,20 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $manager->setSerializer($serializer);
 
         $transformer = Mockery::mock('League\Fractal\TransformerAbstract')->makePartial();
-        $transformer->shouldReceive('getAvailableIncludes')->twice()->andReturn(array('book'));
+        $transformer->shouldReceive('getAvailableIncludes')->twice()->andReturn(['book']);
         $transformer->shouldReceive('transform')->once()->andReturnUsing(function (array $data) {
             return $data;
         });
-        $transformer->shouldReceive('processIncludedResources')->once()->andReturn(array('book' => array('yin' => 'yang')));
+        $transformer->shouldReceive('processIncludedResources')->once()->andReturn(['book' => ['yin' => 'yang']]);
 
-        $resource = new Item(array('bar' => 'baz'), $transformer);
+        $resource = new Item(['bar' => 'baz'], $transformer);
 
         $scope = new Scope($manager, $resource);
 
-        $expected = array(
-            'data' => array('bar' => 'baz'),
-            'sideloaded' => array('book' => array('yin' => 'yang')),
-        );
+        $expected = [
+            'data' => ['bar' => 'baz'],
+            'sideloaded' => ['book' => ['yin' => 'yang']],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
     }
@@ -230,7 +230,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     {
         $manager = new Manager();
 
-        $resource = new Item(array('name' => 'Larry Ullman'), function () {
+        $resource = new Item(['name' => 'Larry Ullman'], function () {
         });
 
         $scope = new Scope($manager, $resource);
@@ -239,7 +239,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, $scope->pushParentScope('author'));
         $this->assertEquals(3, $scope->pushParentScope('profile'));
 
-        $this->assertEquals(array('book', 'author', 'profile'), $scope->getParentScopes());
+        $this->assertEquals(['book', 'author', 'profile'], $scope->getParentScopes());
     }
 
     public function testRunAppropriateTransformerWithItem()
@@ -248,12 +248,12 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
         $transformer = Mockery::mock('League\Fractal\TransformerAbstract');
         $transformer->shouldReceive('transform')->once()->andReturn($this->simpleItem);
-        $transformer->shouldReceive('getAvailableIncludes')->once()->andReturn(array());
-        $transformer->shouldReceive('getDefaultIncludes')->once()->andReturn(array());
+        $transformer->shouldReceive('getAvailableIncludes')->once()->andReturn([]);
+        $transformer->shouldReceive('getDefaultIncludes')->once()->andReturn([]);
 
         $resource = new Item($this->simpleItem, $transformer);
         $scope = $manager->createData($resource);
-        $this->assertEquals(array('data' => $this->simpleItem), $scope->toArray());
+        $this->assertEquals(['data' => $this->simpleItem], $scope->toArray());
     }
 
     public function testRunAppropriateTransformerWithCollection()
@@ -261,14 +261,14 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $manager = new Manager();
 
         $transformer = Mockery::mock('League\Fractal\TransformerAbstract');
-        $transformer->shouldReceive('transform')->once()->andReturn(array('foo' => 'bar'));
-        $transformer->shouldReceive('getAvailableIncludes')->once()->andReturn(array());
-        $transformer->shouldReceive('getDefaultIncludes')->once()->andReturn(array());
+        $transformer->shouldReceive('transform')->once()->andReturn(['foo' => 'bar']);
+        $transformer->shouldReceive('getAvailableIncludes')->once()->andReturn([]);
+        $transformer->shouldReceive('getDefaultIncludes')->once()->andReturn([]);
 
-        $resource = new Collection(array(array('foo' => 'bar')), $transformer);
+        $resource = new Collection([['foo' => 'bar']], $transformer);
         $scope = $manager->createData($resource);
 
-        $this->assertEquals(array('data' => array(array('foo' => 'bar'))), $scope->toArray());
+        $this->assertEquals(['data' => [['foo' => 'bar']]], $scope->toArray());
     }
 
     /**
@@ -282,7 +282,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
         $transformer = Mockery::mock('League\Fractal\TransformerAbstract')->makePartial();
 
-        $resource = Mockery::mock('League\Fractal\Resource\ResourceAbstract', array($this->simpleItem, $transformer))->makePartial();
+        $resource = Mockery::mock('League\Fractal\Resource\ResourceAbstract', [$this->simpleItem, $transformer])->makePartial();
         $scope = $manager->createData($resource);
         $scope->toArray();
     }
@@ -291,7 +291,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     {
         $manager = new Manager();
 
-        $collection = new Collection(array(array('foo' => 'bar', 'baz' => 'ban')), function (array $data) {
+        $collection = new Collection([['foo' => 'bar', 'baz' => 'ban']], function (array $data) {
             return $data;
         });
 
@@ -315,27 +315,27 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
         $rootScope = $manager->createData($collection);
 
-        $expectedOutput = array(
-            'meta' => array(
-                'pagination' => array(
+        $expectedOutput = [
+            'meta' => [
+                'pagination' => [
                     'total' => $total,
                     'count' => $count,
                     'per_page' => $perPage,
                     'current_page' => $currentPage,
                     'total_pages' => $lastPage,
-                    'links' => array(
+                    'links' => [
                         'previous' => 'http://example.com/foo?page=1',
                         'next' => 'http://example.com/foo?page=3',
-                    ),
-                ),
-            ),
-            'data' => array(
-                array(
+                    ],
+                ],
+            ],
+            'data' => [
+                [
                     'foo' => 'bar',
                     'baz' => 'ban',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $this->assertEquals($expectedOutput, $rootScope->toArray());
     }
@@ -344,12 +344,12 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     {
         $manager = new Manager();
 
-        $inputData = array(
-            array(
+        $inputData = [
+            [
                 'foo' => 'bar',
                 'baz' => 'ban',
-            ),
-        );
+            ],
+        ];
 
         $collection = new Collection($inputData, function (array $data) {
             return $data;
@@ -361,17 +361,17 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
         $rootScope = $manager->createData($collection);
 
-        $expectedOutput = array(
-            'meta' => array(
-                'cursor' => array(
+        $expectedOutput = [
+            'meta' => [
+                'cursor' => [
                     'current' => 0,
                     'prev' => 'ban',
                     'next' => 'ban',
                     'count' => 2,
-                ),
-            ),
+                ],
+            ],
             'data' => $inputData,
-        );
+        ];
 
         $this->assertEquals($expectedOutput, $rootScope->toArray());
     }
@@ -382,17 +382,17 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $manager->setSerializer(new ArraySerializer());
 
         // Send this stub junk, it has a specific format anyhow
-        $resource = new Item(array(), new DefaultIncludeBookTransformer());
+        $resource = new Item([], new DefaultIncludeBookTransformer());
 
         // Try without metadata
         $scope = new Scope($manager, $resource);
 
-        $expected = array(
+        $expected = [
             'a' => 'b',
-            'author' => array(
+            'author' => [
                 'c' => 'd',
-            ),
-        );
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
     }

--- a/test/Serializer/ArraySerializerTest.php
+++ b/test/Serializer/ArraySerializerTest.php
@@ -9,30 +9,30 @@ use League\Fractal\Test\Stub\Transformer\GenericBookTransformer;
 
 class ArraySerializerTest extends PHPUnit_Framework_TestCase
 {
-    private $bookItemInput = array(
+    private $bookItemInput = [
         'title' => 'Foo',
         'year' => '1991',
-        '_author' => array(
+        '_author' => [
             'name' => 'Dave',
-        ),
-    );
+        ],
+    ];
 
-    private $bookCollectionInput = array(
-        array(
+    private $bookCollectionInput = [
+        [
             'title' => 'Foo',
             'year' => '1991',
-            '_author' => array(
+            '_author' => [
                 'name' => 'Dave',
-            ),
-        ),
-        array(
+            ],
+        ],
+        [
             'title' => 'Bar',
             'year' => '1997',
-            '_author' => array(
+            '_author' => [
                 'name' => 'Bob',
-            ),
-        ),
-    );
+            ],
+        ],
+    ];
 
     public function testSerializingItemResource()
     {
@@ -45,13 +45,13 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
         // Try without metadata
         $scope = new Scope($manager, $resource);
 
-        $expected = array(
+        $expected = [
             'title' => 'Foo',
             'year' => 1991,
-            'author' => array(
+            'author' => [
                 'name' => 'Dave',
-            ),
-        );
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -60,16 +60,16 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
 
         $scope = new Scope($manager, $resource);
 
-        $expected = array(
+        $expected = [
             'title' => 'Foo',
             'year' => 1991,
-            'author' => array(
+            'author' => [
                 'name' => 'Dave',
-            ),
-            'meta' => array(
+            ],
+            'meta' => [
                 'foo' => 'bar',
-            ),
-        );
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
     }
@@ -85,24 +85,24 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
         // Try without metadata
         $scope = new Scope($manager, $resource);
 
-        $expected = array(
-            'books' => array(
-                array(
+        $expected = [
+            'books' => [
+                [
                     'title' => 'Foo',
                     'year' => 1991,
-                    'author' => array(
+                    'author' => [
                         'name' => 'Dave',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'title' => 'Bar',
                     'year' => 1997,
-                    'author' => array(
+                    'author' => [
                         'name' => 'Bob',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -115,27 +115,27 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
 
         $scope = new Scope($manager, $resource);
 
-        $expected = array(
-            'books' => array(
-                array(
+        $expected = [
+            'books' => [
+                [
                     'title' => 'Foo',
                     'year' => 1991,
-                    'author' => array(
+                    'author' => [
                         'name' => 'Dave',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'title' => 'Bar',
                     'year' => 1997,
-                    'author' => array(
+                    'author' => [
                         'name' => 'Bob',
-                    ),
-                ),
-            ),
-            'meta' => array(
+                    ],
+                ],
+            ],
+            'meta' => [
                 'foo' => 'bar',
-            ),
-        );
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 

--- a/test/Serializer/DataArraySerializerTest.php
+++ b/test/Serializer/DataArraySerializerTest.php
@@ -15,29 +15,29 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
         $manager->parseIncludes('author');
         $manager->setSerializer(new DataArraySerializer());
 
-        $bookData = array(
+        $bookData = [
             'title' => 'Foo',
             'year' => '1991',
-            '_author' => array(
+            '_author' => [
                 'name' => 'Dave',
-            ),
-        );
+            ],
+        ];
 
         // Try without metadata
         $resource = new Item($bookData, new GenericBookTransformer(), 'book');
         $scope = new Scope($manager, $resource);
 
-        $expected = array(
-            'data' => array(
+        $expected = [
+            'data' => [
                 'title' => 'Foo',
                 'year' => 1991,
-                'author' => array(
-                    'data' => array(
+                'author' => [
+                    'data' => [
                         'name' => 'Dave',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -47,20 +47,20 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
 
         $scope = new Scope($manager, $resource);
 
-        $expected = array(
-            'meta' => array(
+        $expected = [
+            'meta' => [
                 'foo' => 'bar',
-            ),
-            'data' => array(
+            ],
+            'data' => [
                 'title' => 'Foo',
                 'year' => 1991,
-                'author' => array(
-                    'data' => array(
+                'author' => [
+                    'data' => [
                         'name' => 'Dave',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
     }
@@ -71,50 +71,50 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
         $manager->parseIncludes('author');
         $manager->setSerializer(new DataArraySerializer());
 
-        $booksData = array(
-            array(
+        $booksData = [
+            [
                 'title' => 'Foo',
                 'year' => '1991',
-                '_author' => array(
+                '_author' => [
                     'name' => 'Dave',
-                ),
-            ),
-            array(
+                ],
+            ],
+            [
                 'title' => 'Bar',
                 'year' => '1997',
-                '_author' => array(
+                '_author' => [
                     'name' => 'Bob',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         // Try without metadata
         $resource = new Collection($booksData, new GenericBookTransformer(), 'book');
 
         $scope = new Scope($manager, $resource);
 
-        $expected = array(
-            'data' => array(
-                array(
+        $expected = [
+            'data' => [
+                [
                     'title' => 'Foo',
                     'year' => 1991,
-                    'author' => array(
-                        'data' => array(
+                    'author' => [
+                        'data' => [
                             'name' => 'Dave',
-                        ),
-                    ),
-                ),
-                array(
+                        ],
+                    ],
+                ],
+                [
                     'title' => 'Bar',
                     'year' => 1997,
-                    'author' => array(
-                        'data' => array(
+                    'author' => [
+                        'data' => [
                             'name' => 'Bob',
-                        ),
-                    ),
-                ),
-            ),
-        );
+                        ],
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -127,31 +127,31 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
 
         $scope = new Scope($manager, $resource);
 
-        $expected = array(
-            'meta' => array(
+        $expected = [
+            'meta' => [
                 'foo' => 'bar',
-            ),
-            'data' => array(
-                array(
+            ],
+            'data' => [
+                [
                     'title' => 'Foo',
                     'year' => 1991,
-                    'author' => array(
-                        'data' => array(
+                    'author' => [
+                        'data' => [
                             'name' => 'Dave',
-                        ),
-                    ),
-                ),
-                array(
+                        ],
+                    ],
+                ],
+                [
                     'title' => 'Bar',
                     'year' => 1997,
-                    'author' => array(
-                        'data' => array(
+                    'author' => [
+                        'data' => [
                             'name' => 'Bob',
-                        ),
-                    ),
-                ),
-            ),
-        );
+                        ],
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -22,47 +22,47 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     {
         $this->manager->parseIncludes('author');
 
-        $bookData = array(
+        $bookData = [
             'id' => 1,
             'title' => 'Foo',
             'year' => '1991',
-            '_author' => array(
+            '_author' => [
                 'id' => 1,
                 'name' => 'Dave',
-            ),
-        );
+            ],
+        ];
 
         $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
+        $expected = [
+            'data' => [
                 'type' => 'books',
                 'id' => '1',
-                'attributes' => array(
+                'attributes' => [
                     'title' => 'Foo',
                     'year' => 1991,
-                ),
-                'relationships' => array(
-                    'author' => array(
-                        'data' => array(
+                ],
+                'relationships' => [
+                    'author' => [
+                        'data' => [
                             'type' => 'people',
                             'id' => '1',
-                        ),
-                    ),
-                ),
-            ),
-            'included' => array(
-                array(
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
                     'type' => 'people',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'name' => 'Dave',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -74,32 +74,32 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     {
         $this->manager->parseIncludes('author');
 
-        $bookData = array(
+        $bookData = [
             'id' => 1,
             'title' => 'Foo',
             'year' => '1991',
             '_author' => null,
-        );
+        ];
 
         $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
+        $expected = [
+            'data' => [
                 'type' => 'books',
                 'id' => '1',
-                'attributes' => array(
+                'attributes' => [
                     'title' => 'Foo',
                     'year' => 1991,
-                ),
-                'relationships' => array(
-                    'author' => array(
+                ],
+                'relationships' => [
+                    'author' => [
                         'data' => null,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -111,68 +111,68 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     {
         $this->manager->parseIncludes('published');
 
-        $authorData = array(
+        $authorData = [
             'id' => 1,
             'name' => 'Dave',
-            '_published' => array(
-                array(
+            '_published' => [
+                [
                     'id' => 1,
                     'title' => 'Foo',
                     'year' => '1991',
-                ),
-                array(
+                ],
+                [
                     'id' => 2,
                     'title' => 'Bar',
                     'year' => '2015',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $resource = new Item($authorData, new JsonApiAuthorTransformer(), 'people');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
+        $expected = [
+            'data' => [
                 'type' => 'people',
                 'id' => '1',
-                'attributes' => array(
+                'attributes' => [
                     'name' => 'Dave',
-                ),
-                'relationships' => array(
-                    'published' => array(
-                        'data' => array(
-                            array(
+                ],
+                'relationships' => [
+                    'published' => [
+                        'data' => [
+                            [
                                 'type' => 'books',
                                 'id' => 1,
-                            ),
-                            array(
+                            ],
+                            [
                                 'type' => 'books',
                                 'id' => 2,
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-            'included' => array(
-                array(
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
                     'type' => 'books',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Foo',
                         'year' => 1991,
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Bar',
                         'year' => 2015,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -184,30 +184,30 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     {
         $this->manager->parseIncludes('published');
 
-        $authorData = array(
+        $authorData = [
             'id' => 1,
             'name' => 'Dave',
-            '_published' => array(),
-        );
+            '_published' => [],
+        ];
 
         $resource = new Item($authorData, new JsonApiAuthorTransformer(), 'people');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
+        $expected = [
+            'data' => [
                 'type' => 'people',
                 'id' => '1',
-                'attributes' => array(
+                'attributes' => [
                     'name' => 'Dave',
-                ),
-                'relationships' => array(
-                    'published' => array(
-                        'data' => array(),
-                    ),
-                ),
-            ),
-        );
+                ],
+                'relationships' => [
+                    'published' => [
+                        'data' => [],
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -217,30 +217,30 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
     public function testSerializingItemResourceWithoutIncludes()
     {
-        $bookData = array(
+        $bookData = [
             'id' => 1,
             'title' => 'Foo',
             'year' => '1991',
-            '_author' => array(
+            '_author' => [
                 'id' => 1,
                 'name' => 'Dave',
-            ),
-        );
+            ],
+        ];
 
         $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
+        $expected = [
+            'data' => [
                 'type' => 'books',
                 'id' => '1',
-                'attributes' => array(
+                'attributes' => [
                     'title' => 'Foo',
                     'year' => 1991,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -250,34 +250,34 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
     public function testSerializingItemResourceWithMeta()
     {
-        $bookData = array(
+        $bookData = [
             'id' => 1,
             'title' => 'Foo',
             'year' => '1991',
-            '_author' => array(
+            '_author' => [
                 'id' => 1,
                 'name' => 'Dave',
-            ),
-        );
+            ],
+        ];
 
         $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
         $resource->setMetaValue('foo', 'bar');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
+        $expected = [
+            'data' => [
                 'type' => 'books',
                 'id' => '1',
-                'attributes' => array(
+                'attributes' => [
                     'title' => 'Foo',
                     'year' => 1991,
-                ),
-            ),
-            'meta' => array(
+                ],
+            ],
+            'meta' => [
                 'foo' => 'bar',
-            ),
-        );
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -287,50 +287,50 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
     public function testSerializingCollectionResourceWithoutIncludes()
     {
-        $booksData = array(
-            array(
+        $booksData = [
+            [
                 'id' => 1,
                 'title' => 'Foo',
                 'year' => '1991',
-                '_author' => array(
+                '_author' => [
                     'id' => 1,
                     'name' => 'Dave',
-                ),
-            ),
-            array(
+                ],
+            ],
+            [
                 'id' => 2,
                 'title' => 'Bar',
                 'year' => '1997',
-                '_author' => array(
+                '_author' => [
                     'id' => 2,
                     'name' => 'Bob',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
-                array(
+        $expected = [
+            'data' => [
+                [
                     'type' => 'books',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Foo',
                         'year' => 1991,
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Bar',
                         'year' => 1997,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -342,82 +342,82 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     {
         $this->manager->parseIncludes('author');
 
-        $booksData = array(
-            array(
+        $booksData = [
+            [
                 'id' => 1,
                 'title' => 'Foo',
                 'year' => '1991',
-                '_author' => array(
+                '_author' => [
                     'id' => 1,
                     'name' => 'Dave',
-                ),
-            ),
-            array(
+                ],
+            ],
+            [
                 'id' => 2,
                 'title' => 'Bar',
                 'year' => '1997',
-                '_author' => array(
+                '_author' => [
                     'id' => 2,
                     'name' => 'Bob',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
-                array(
+        $expected = [
+            'data' => [
+                [
                     'type' => 'books',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Foo',
                         'year' => 1991,
-                    ),
-                    'relationships' => array(
-                        'author' => array(
-                            'data' => array(
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'data' => [
                                 'type' => 'people',
                                 'id' => '1',
-                            ),
-                        ),
-                    ),
-                ),
-                array(
+                            ],
+                        ],
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Bar',
                         'year' => 1997,
-                    ),
-                    'relationships' => array(
-                        'author' => array(
-                            'data' => array(
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'data' => [
                                 'type' => 'people',
                                 'id' => '2',
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-            'included' => array(
-                array(
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
                     'type' => 'people',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'name' => 'Dave',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'type' => 'people',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'name' => 'Bob',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -429,69 +429,69 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     {
         $this->manager->parseIncludes('author');
 
-        $booksData = array(
-            array(
+        $booksData = [
+            [
                 'id' => 1,
                 'title' => 'Foo',
                 'year' => '1991',
                 '_author' => null,
-            ),
-            array(
+            ],
+            [
                 'id' => 2,
                 'title' => 'Bar',
                 'year' => '1997',
-                '_author' => array(
+                '_author' => [
                     'id' => 2,
                     'name' => 'Bob',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
-                array(
+        $expected = [
+            'data' => [
+                [
                     'type' => 'books',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Foo',
                         'year' => 1991,
-                    ),
-                    'relationships' => array(
-                        'author' => array(
+                    ],
+                    'relationships' => [
+                        'author' => [
                             'data' => null,
-                        ),
-                    ),
-                ),
-                array(
+                        ],
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Bar',
                         'year' => 1997,
-                    ),
-                    'relationships' => array(
-                        'author' => array(
-                            'data' => array(
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'data' => [
                                 'type' => 'people',
                                 'id' => '2',
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-            'included' => array(
-                array(
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
                     'type' => 'people',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'name' => 'Bob',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -503,124 +503,124 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     {
         $this->manager->parseIncludes('published');
 
-        $authorsData = array(
-            array(
+        $authorsData = [
+            [
                 'id' => 1,
                 'name' => 'Dave',
-                '_published' => array(
-                    array(
+                '_published' => [
+                    [
                         'id' => 1,
                         'title' => 'Foo',
                         'year' => '1991',
-                    ),
-                    array(
+                    ],
+                    [
                         'id' => 2,
                         'title' => 'Bar',
                         'year' => '2015',
-                    ),
-                ),
-            ),
-            array(
+                    ],
+                ],
+            ],
+            [
                 'id' => 2,
                 'name' => 'Bob',
-                '_published' => array(
-                    array(
+                '_published' => [
+                    [
                         'id' => 3,
                         'title' => 'Baz',
                         'year' => '1995',
-                    ),
-                    array(
+                    ],
+                    [
                         'id' => 4,
                         'title' => 'Quux',
                         'year' => '2000',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $resource = new Collection($authorsData, new JsonApiAuthorTransformer(), 'people');
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
-                array(
+        $expected = [
+            'data' => [
+                [
                     'type' => 'people',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'name' => 'Dave',
-                    ),
-                    'relationships' => array(
-                        'published' => array(
-                            'data' => array(
-                                array(
+                    ],
+                    'relationships' => [
+                        'published' => [
+                            'data' => [
+                                [
                                     'type' => 'books',
                                     'id' => 1,
-                                ),
-                                array(
+                                ],
+                                [
                                     'type' => 'books',
                                     'id' => 2,
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-                array(
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
                     'type' => 'people',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'name' => 'Bob',
-                    ),
-                    'relationships' => array(
-                        'published' => array(
-                            'data' => array(
-                                array(
+                    ],
+                    'relationships' => [
+                        'published' => [
+                            'data' => [
+                                [
                                     'type' => 'books',
                                     'id' => 3,
-                                ),
-                                array(
+                                ],
+                                [
                                     'type' => 'books',
                                     'id' => 4,
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-            'included' => array(
-                array(
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
                     'type' => 'books',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Foo',
                         'year' => 1991,
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Bar',
                         'year' => 2015,
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '3',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Baz',
                         'year' => 1995,
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '4',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Quux',
                         'year' => 2000,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -632,71 +632,71 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     {
         $this->manager->parseIncludes('published');
 
-        $authorsData = array(
-            array(
+        $authorsData = [
+            [
                 'id' => 1,
                 'name' => 'Dave',
-                '_published' => array(),
-            ),
-            array(
+                '_published' => [],
+            ],
+            [
                 'id' => 2,
                 'name' => 'Bob',
-                '_published' => array(
-                    array(
+                '_published' => [
+                    [
                         'id' => 3,
                         'title' => 'Baz',
                         'year' => '1995',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $resource = new Collection($authorsData, new JsonApiAuthorTransformer(), 'people');
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
-                array(
+        $expected = [
+            'data' => [
+                [
                     'type' => 'people',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'name' => 'Dave',
-                    ),
-                    'relationships' => array(
-                        'published' => array(
-                            'data' => array(),
-                        ),
-                    ),
-                ),
-                array(
+                    ],
+                    'relationships' => [
+                        'published' => [
+                            'data' => [],
+                        ],
+                    ],
+                ],
+                [
                     'type' => 'people',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'name' => 'Bob',
-                    ),
-                    'relationships' => array(
-                        'published' => array(
-                            'data' => array(
-                                array(
+                    ],
+                    'relationships' => [
+                        'published' => [
+                            'data' => [
+                                [
                                     'type' => 'books',
                                     'id' => 3,
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-            'included' => array(
-                array(
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
                     'type' => 'books',
                     'id' => '3',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Baz',
                         'year' => 1995,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -706,53 +706,53 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
     public function testSerializingCollectionResourceWithMeta()
     {
-        $booksData = array(
-            array(
+        $booksData = [
+            [
                 'id' => 1,
                 'title' => 'Foo',
                 'year' => '1991',
-                '_author' => array(
+                '_author' => [
                     'name' => 'Dave',
-                ),
-            ),
-            array(
+                ],
+            ],
+            [
                 'id' => 2,
                 'title' => 'Bar',
                 'year' => '1997',
-                '_author' => array(
+                '_author' => [
                     'name' => 'Bob',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
         $resource->setMetaValue('foo', 'bar');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
-                array(
+        $expected = [
+            'data' => [
+                [
                     'type' => 'books',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Foo',
                         'year' => 1991,
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Bar',
                         'year' => 1997,
-                    ),
-                ),
-            ),
-            'meta' => array(
+                    ],
+                ],
+            ],
+            'meta' => [
                 'foo' => 'bar',
-            ),
-        );
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -764,75 +764,75 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     {
         $this->manager->parseIncludes('author');
 
-        $booksData = array(
-            array(
+        $booksData = [
+            [
                 'id' => 1,
                 'title' => 'Foo',
                 'year' => '1991',
-                '_author' => array(
+                '_author' => [
                     'id' => 1,
                     'name' => 'Dave',
-                ),
-            ),
-            array(
+                ],
+            ],
+            [
                 'id' => 2,
                 'title' => 'Bar',
                 'year' => '1997',
-                '_author' => array(
+                '_author' => [
                     'id' => 1,
                     'name' => 'Dave',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
-                array(
+        $expected = [
+            'data' => [
+                [
                     'type' => 'books',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Foo',
                         'year' => 1991,
-                    ),
-                    'relationships' => array(
-                        'author' => array(
-                            'data' => array(
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'data' => [
                                 'type' => 'people',
                                 'id' => '1',
-                            ),
-                        ),
-                    ),
-                ),
-                array(
+                            ],
+                        ],
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Bar',
                         'year' => 1997,
-                    ),
-                    'relationships' => array(
-                        'author' => array(
-                            'data' => array(
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'data' => [
                                 'type' => 'people',
                                 'id' => '1',
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-            'included' => array(
-                array(
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
                     'type' => 'people',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'name' => 'Dave',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -844,81 +844,81 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     {
         $this->manager->parseIncludes(['author', 'author.published']);
 
-        $bookData = array(
+        $bookData = [
             'id' => 1,
             'title' => 'Foo',
             'year' => '1991',
-            '_author' => array(
+            '_author' => [
                 'id' => 1,
                 'name' => 'Dave',
-                '_published' => array(
-                    array(
+                '_published' => [
+                    [
                         'id' => 1,
                         'title' => 'Foo',
                         'year' => '1991',
-                    ),
-                    array(
+                    ],
+                    [
                         'id' => 2,
                         'title' => 'Bar',
                         'year' => '2015',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
+        $expected = [
+            'data' => [
                 'type' => 'books',
                 'id' => '1',
-                'attributes' => array(
+                'attributes' => [
                     'title' => 'Foo',
                     'year' => 1991,
-                ),
-                'relationships' => array(
-                    'author' => array(
-                        'data' => array(
+                ],
+                'relationships' => [
+                    'author' => [
+                        'data' => [
                             'type' => 'people',
                             'id' => '1',
-                        ),
-                    ),
-                ),
-            ),
-            'included' => array(
-                array(
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
                     'type' => 'books',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Bar',
                         'year' => 2015,
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'type' => 'people',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'name' => 'Dave',
-                    ),
-                    'relationships' => array(
-                        'published' => array(
-                            'data' => array(
-                                array(
+                    ],
+                    'relationships' => [
+                        'published' => [
+                            'data' => [
+                                [
                                     'type' => 'books',
                                     'id' => '1',
-                                ),
-                                array(
+                                ],
+                                [
                                     'type' => 'books',
                                     'id' => '2',
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-        );
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -931,33 +931,33 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $baseUrl = 'http://example.com';
         $this->manager->setSerializer(new JsonApiSerializer($baseUrl));
 
-        $bookData = array(
+        $bookData = [
             'id' => 1,
             'title' => 'Foo',
             'year' => '1991',
-            '_author' => array(
+            '_author' => [
                 'id' => 1,
                 'name' => 'Dave',
-            ),
-        );
+            ],
+        ];
 
         $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
+        $expected = [
+            'data' => [
                 'type' => 'books',
                 'id' => '1',
-                'attributes' => array(
+                'attributes' => [
                     'title' => 'Foo',
                     'year' => 1991,
-                ),
-                'links' => array(
+                ],
+                'links' => [
                     'self' => 'http://example.com/books/1',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -970,56 +970,56 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $baseUrl = 'http://example.com';
         $this->manager->setSerializer(new JsonApiSerializer($baseUrl));
 
-        $booksData = array(
-            array(
+        $booksData = [
+            [
                 'id' => 1,
                 'title' => 'Foo',
                 'year' => '1991',
-                '_author' => array(
+                '_author' => [
                     'id' => 1,
                     'name' => 'Dave',
-                ),
-            ),
-            array(
+                ],
+            ],
+            [
                 'id' => 2,
                 'title' => 'Bar',
                 'year' => '1997',
-                '_author' => array(
+                '_author' => [
                     'id' => 2,
                     'name' => 'Bob',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
-                array(
+        $expected = [
+            'data' => [
+                [
                     'type' => 'books',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Foo',
                         'year' => 1991,
-                    ),
-                    'links' => array(
+                    ],
+                    'links' => [
                         'self' => 'http://example.com/books/1',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Bar',
                         'year' => 1997,
-                    ),
-                    'links' => array(
+                    ],
+                    'links' => [
                         'self' => 'http://example.com/books/2',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -1033,57 +1033,57 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $this->manager->setSerializer(new JsonApiSerializer($baseUrl));
         $this->manager->parseIncludes('author');
 
-        $bookData = array(
+        $bookData = [
             'id' => 1,
             'title' => 'Foo',
             'year' => '1991',
-            '_author' => array(
+            '_author' => [
                 'id' => 1,
                 'name' => 'Dave',
-            ),
-        );
+            ],
+        ];
 
         $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
+        $expected = [
+            'data' => [
                 'type' => 'books',
                 'id' => '1',
-                'attributes' => array(
+                'attributes' => [
                     'title' => 'Foo',
                     'year' => 1991,
-                ),
-                'relationships' => array(
-                    'author' => array(
-                        'links' => array(
+                ],
+                'relationships' => [
+                    'author' => [
+                        'links' => [
                             'self' => 'http://example.com/books/1/relationships/author',
                             'related' => 'http://example.com/books/1/author',
-                        ),
-                        'data' => array(
+                        ],
+                        'data' => [
                             'type' => 'people',
                             'id' => '1',
-                        ),
-                    ),
-                ),
-                'links' => array(
+                        ],
+                    ],
+                ],
+                'links' => [
                     'self' => 'http://example.com/books/1',
-                ),
-            ),
-            'included' => array(
-                array(
+                ],
+            ],
+            'included' => [
+                [
                     'type' => 'people',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'name' => 'Dave',
-                    ),
-                    'links' => array(
+                    ],
+                    'links' => [
                         'self' => 'http://example.com/people/1',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -1097,81 +1097,81 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $this->manager->setSerializer(new JsonApiSerializer($baseUrl));
         $this->manager->parseIncludes('published');
 
-        $authorData = array(
+        $authorData = [
             'id' => 1,
             'name' => 'Dave',
-            '_published' => array(
-                array(
+            '_published' => [
+                [
                     'id' => 1,
                     'title' => 'Foo',
                     'year' => '1991',
-                ),
-                array(
+                ],
+                [
                     'id' => 2,
                     'title' => 'Bar',
                     'year' => '2015',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $resource = new Item($authorData, new JsonApiAuthorTransformer(), 'people');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
+        $expected = [
+            'data' => [
                 'type' => 'people',
                 'id' => '1',
-                'attributes' => array(
+                'attributes' => [
                     'name' => 'Dave',
-                ),
-                'relationships' => array(
-                    'published' => array(
-                        'links' => array(
+                ],
+                'relationships' => [
+                    'published' => [
+                        'links' => [
                             'self' => 'http://example.com/people/1/relationships/published',
                             'related' => 'http://example.com/people/1/published',
-                        ),
-                        'data' => array(
-                            array(
+                        ],
+                        'data' => [
+                            [
                                 'type' => 'books',
                                 'id' => 1,
-                            ),
-                            array(
+                            ],
+                            [
                                 'type' => 'books',
                                 'id' => 2,
-                            ),
-                        ),
-                    ),
-                ),
-                'links' => array(
+                            ],
+                        ],
+                    ],
+                ],
+                'links' => [
                     'self' => 'http://example.com/people/1',
-                ),
-            ),
-            'included' => array(
-                array(
+                ],
+            ],
+            'included' => [
+                [
                     'type' => 'books',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Foo',
                         'year' => 1991,
-                    ),
-                    'links' => array(
+                    ],
+                    'links' => [
                         'self' => 'http://example.com/books/1',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Bar',
                         'year' => 2015,
-                    ),
-                    'links' => array(
+                    ],
+                    'links' => [
                         'self' => 'http://example.com/books/2',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -1185,10 +1185,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
      */
     public function testExceptionThrownIfResourceHasNoId()
     {
-        $bookData = array(
+        $bookData = [
             'title' => 'Foo',
             'year' => '1991',
-        );
+        ];
 
         $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
 
@@ -1200,74 +1200,74 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     {
         $this->manager->parseIncludes('published.author');
 
-        $authorData = array(
+        $authorData = [
             'id' => 1,
             'name' => 'Dave',
-            '_published' => array(
-                array(
+            '_published' => [
+                [
                     'id' => 1,
                     'title' => 'Foo',
                     'year' => 1991,
-                    '_author' => array('id' => 1)
-                ),
-                array(
+                    '_author' => ['id' => 1]
+                ],
+                [
                     'id' => 2,
                     'title' => 'Bar',
                     'year' => 2015,
-                    '_author' => array('id' => 1)
-                ),
-            ),
-        );
+                    '_author' => ['id' => 1]
+                ],
+            ],
+        ];
 
         $resource = new Item($authorData, new JsonApiAuthorTransformer(), 'people');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
+        $expected = [
+            'data' => [
                 'type' => 'people',
                 'id' => '1',
-                'attributes' => array(
+                'attributes' => [
                     'name' => 'Dave',
-                ),
-                'relationships' => array(
-                    'published' => array(
-                        'data' => array(
-                            array('type' => 'books', 'id' => '1'),
-                            array('type' => 'books', 'id' => '2'),
-                        ),
-                    ),
-                ),
-            ),
-            'included' => array(
-                array(
+                ],
+                'relationships' => [
+                    'published' => [
+                        'data' => [
+                            ['type' => 'books', 'id' => '1'],
+                            ['type' => 'books', 'id' => '2'],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
                     'type' => 'books',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Foo',
                         'year' => 1991,
-                    ),
-                    'relationships' => array(
-                        'author' => array(
-                            'data' => array('type' => 'people', 'id' => '1'),
-                        ),
-                    ),
-                ),
-                array(
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'data' => ['type' => 'people', 'id' => '1'],
+                        ],
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Bar',
                         'year' => 2015,
-                    ),
-                    'relationships' => array(
-                        'author' => array(
-                            'data' => array('type' => 'people', 'id' => '1'),
-                        ),
-                    ),
-                ),
-            ),
-        );
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'data' => ['type' => 'people', 'id' => '1'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 
@@ -1279,107 +1279,107 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     {
         $this->manager->parseIncludes('author.published');
 
-        $booksData = array(
-            array(
+        $booksData = [
+            [
                 'id' => 1,
                 'title' => 'Foo',
                 'year' => 1991,
-                '_author' => array(
+                '_author' => [
                     'id' => 1,
                     'name' => 'Dave',
-                    '_published' => array(
-                        array(
+                    '_published' => [
+                        [
                             'id' => 1,
                             'title' => 'Foo',
                             'year' => 1991,
-                        ),
-                        array(
+                        ],
+                        [
                             'id' => 2,
                             'title' => 'Bar',
                             'year' => 2015,
-                        ),
-                    ),
-                ),
-            ),
-            array(
+                        ],
+                    ],
+                ],
+            ],
+            [
                 'id' => 2,
                 'title' => 'Bar',
                 'year' => 2015,
-                '_author' => array(
+                '_author' => [
                     'id' => 1,
-                    '_published' => array(
-                        array(
+                    '_published' => [
+                        [
                             'id' => 1,
                             'title' => 'Foo',
                             'year' => 1991,
-                        ),
-                        array(
+                        ],
+                        [
                             'id' => 2,
                             'title' => 'Bar',
                             'year' => 2015,
-                        ),
-                    ),
-                ),
-            ),
-        );
+                        ],
+                    ],
+                ],
+            ],
+        ];
 
         $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
 
         $scope = new Scope($this->manager, $resource);
 
-        $expected = array(
-            'data' => array(
-                array(
+        $expected = [
+            'data' => [
+                [
                     'type' => 'books',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Foo',
                         'year' => 1991,
-                    ),
-                    'relationships' => array(
-                        'author' => array(
-                            'data' => array(
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'data' => [
                                 'type' => 'people',
                                 'id' => '1',
-                            ),
-                        ),
-                    ),
-                ),
-                array(
+                            ],
+                        ],
+                    ],
+                ],
+                [
                     'type' => 'books',
                     'id' => '2',
-                    'attributes' => array(
+                    'attributes' => [
                         'title' => 'Bar',
                         'year' => 2015,
-                    ),
-                    'relationships' => array(
-                        'author' => array(
-                            'data' => array(
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'data' => [
                                 'type' => 'people',
                                 'id' => '1',
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-            'included' => array(
-                array(
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
                     'type' => 'people',
                     'id' => '1',
-                    'attributes' => array(
+                    'attributes' => [
                         'name' => 'Dave',
-                    ),
-                    'relationships' => array(
-                        'published' => array(
-                            'data' => array(
-                                array('type' => 'books', 'id' => '1'),
-                                array('type' => 'books', 'id' => '2'),
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-        );
+                    ],
+                    'relationships' => [
+                        'published' => [
+                            'data' => [
+                                ['type' => 'books', 'id' => '1'],
+                                ['type' => 'books', 'id' => '2'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $scope->toArray());
 

--- a/test/Stub/Transformer/DefaultIncludeBookTransformer.php
+++ b/test/Stub/Transformer/DefaultIncludeBookTransformer.php
@@ -4,17 +4,17 @@ use League\Fractal\TransformerAbstract;
 
 class DefaultIncludeBookTransformer extends TransformerAbstract
 {
-    protected $defaultIncludes = array(
+    protected $defaultIncludes = [
         'author',
-    );
+    ];
 
     public function transform()
     {
-        return array('a' => 'b');
+        return ['a' => 'b'];
     }
 
     public function includeAuthor()
     {
-        return $this->item(array('c' => 'd'), new GenericAuthorTransformer());
+        return $this->item(['c' => 'd'], new GenericAuthorTransformer());
     }
 }

--- a/test/Stub/Transformer/GenericBookTransformer.php
+++ b/test/Stub/Transformer/GenericBookTransformer.php
@@ -4,9 +4,9 @@ use League\Fractal\TransformerAbstract;
 
 class GenericBookTransformer extends TransformerAbstract
 {
-    protected $availableIncludes = array(
+    protected $availableIncludes = [
         'author',
-    );
+    ];
 
     public function transform(array $book)
     {

--- a/test/Stub/Transformer/JsonApiAuthorTransformer.php
+++ b/test/Stub/Transformer/JsonApiAuthorTransformer.php
@@ -4,9 +4,9 @@ use League\Fractal\TransformerAbstract;
 
 class JsonApiAuthorTransformer extends TransformerAbstract
 {
-    protected $availableIncludes = array(
+    protected $availableIncludes = [
         'published',
-    );
+    ];
 
     public function transform(array $author)
     {

--- a/test/Stub/Transformer/JsonApiBookTransformer.php
+++ b/test/Stub/Transformer/JsonApiBookTransformer.php
@@ -4,9 +4,9 @@ use League\Fractal\TransformerAbstract;
 
 class JsonApiBookTransformer extends TransformerAbstract
 {
-    protected $availableIncludes = array(
+    protected $availableIncludes = [
         'author',
-    );
+    ];
 
     public function transform(array $book)
     {

--- a/test/TransformerAbstractTest.php
+++ b/test/TransformerAbstractTest.php
@@ -14,7 +14,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     public function testSetAvailableIncludes()
     {
         $transformer = m::mock('League\Fractal\TransformerAbstract')->makePartial();
-        $this->assertInstanceOf('League\Fractal\TransformerAbstract', $transformer->setAvailableIncludes(array('foo')));
+        $this->assertInstanceOf('League\Fractal\TransformerAbstract', $transformer->setAvailableIncludes(['foo']));
     }
 
     /**
@@ -23,8 +23,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     public function testGetAvailableIncludes()
     {
         $transformer = m::mock('League\Fractal\TransformerAbstract')->makePartial();
-        $transformer->setAvailableIncludes(array('foo', 'bar'));
-        $this->assertEquals(array('foo', 'bar'), $transformer->getAvailableIncludes());
+        $transformer->setAvailableIncludes(['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar'], $transformer->getAvailableIncludes());
     }
 
     /**
@@ -33,7 +33,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     public function testSetDefaultIncludes()
     {
         $transformer = m::mock('League\Fractal\TransformerAbstract')->makePartial();
-        $this->assertInstanceOf('League\Fractal\TransformerAbstract', $transformer->setDefaultIncludes(array('foo')));
+        $this->assertInstanceOf('League\Fractal\TransformerAbstract', $transformer->setDefaultIncludes(['foo']));
     }
 
     /**
@@ -42,8 +42,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     public function testGetDefaultIncludes()
     {
         $transformer = m::mock('League\Fractal\TransformerAbstract')->makePartial();
-        $transformer->setDefaultIncludes(array('foo', 'bar'));
-        $this->assertEquals(array('foo', 'bar'), $transformer->getDefaultIncludes());
+        $transformer->setDefaultIncludes(['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar'], $transformer->getDefaultIncludes());
     }
 
     /**
@@ -77,7 +77,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
         $manager->parseIncludes('foo');
 
         $scope = new Scope($manager, m::mock('League\Fractal\Resource\ResourceAbstract'));
-        $this->assertFalse($transformer->processIncludedResources($scope, array('some' => 'data')));
+        $this->assertFalse($transformer->processIncludedResources($scope, ['some' => 'data']));
     }
 
     public function testProcessEmbeddedResourcesNoDefaultIncludes()
@@ -88,7 +88,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
         $manager->parseIncludes('foo');
 
         $scope = new Scope($manager, m::mock('League\Fractal\Resource\ResourceAbstract'));
-        $this->assertFalse($transformer->processIncludedResources($scope, array('some' => 'data')));
+        $this->assertFalse($transformer->processIncludedResources($scope, ['some' => 'data']));
     }
 
     /**
@@ -106,8 +106,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
         $scope = new Scope($manager, m::mock('League\Fractal\Resource\ResourceAbstract'));
         $transformer->setCurrentScope($scope);
 
-        $transformer->setAvailableIncludes(array('book'));
-        $transformer->processIncludedResources($scope, array());
+        $transformer->setAvailableIncludes(['book']);
+        $transformer->processIncludedResources($scope, []);
     }
 
     /**
@@ -123,8 +123,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
 
         $scope = new Scope($manager, m::mock('League\Fractal\Resource\ResourceAbstract'));
 
-        $transformer->setDefaultIncludes(array('book'));
-        $transformer->processIncludedResources($scope, array());
+        $transformer->setDefaultIncludes(['book']);
+        $transformer->processIncludedResources($scope, []);
     }
 
     /**
@@ -138,14 +138,14 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
         $transformer = m::mock('League\Fractal\TransformerAbstract[transform]');
 
         $transformer->shouldReceive('includeBook')->once()->andReturnUsing(function ($data) {
-            return new Item(array('included' => 'thing'), function ($data) {
+            return new Item(['included' => 'thing'], function ($data) {
                 return $data;
             });
         });
-        $transformer->setAvailableIncludes(array('book', 'publisher'));
-        $scope = new Scope($manager, new Item(array(), $transformer));
-        $included = $transformer->processIncludedResources($scope, array('meh'));
-        $this->assertEquals(array('book' => array('data' => array('included' => 'thing'))), $included);
+        $transformer->setAvailableIncludes(['book', 'publisher']);
+        $scope = new Scope($manager, new Item([], $transformer));
+        $included = $transformer->processIncludedResources($scope, ['meh']);
+        $this->assertEquals(['book' => ['data' => ['included' => 'thing']]], $included);
     }
 
     /**
@@ -155,14 +155,14 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     public function testProcessIncludedAvailableResourcesEmptyEmbed()
     {
         $manager = new Manager();
-        $manager->parseIncludes(array('book'));
+        $manager->parseIncludes(['book']);
         $transformer = m::mock('League\Fractal\TransformerAbstract[transform]');
 
         $transformer->shouldReceive('includeBook')->once()->andReturn(null);
 
-        $transformer->setAvailableIncludes(array('book'));
-        $scope = new Scope($manager, new Item(array(), $transformer));
-        $included = $transformer->processIncludedResources($scope, array('meh'));
+        $transformer->setAvailableIncludes(['book']);
+        $scope = new Scope($manager, new Item([], $transformer));
+        $included = $transformer->processIncludedResources($scope, ['meh']);
 
         $this->assertFalse($included);
     }
@@ -180,9 +180,9 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
 
         $transformer->shouldReceive('includeBook')->once()->andReturn(new \stdClass());
 
-        $transformer->setAvailableIncludes(array('book'));
-        $scope = new Scope($manager, new Item(array(), $transformer));
-        $transformer->processIncludedResources($scope, array('meh'));
+        $transformer->setAvailableIncludes(['book']);
+        $scope = new Scope($manager, new Item([], $transformer));
+        $transformer->processIncludedResources($scope, ['meh']);
     }
 
     /**
@@ -195,14 +195,14 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
         $transformer = m::mock('League\Fractal\TransformerAbstract[transform]');
 
         $transformer->shouldReceive('includeBook')->once()->andReturnUsing(function ($data) {
-            return new Item(array('included' => 'thing'), function ($data) {
+            return new Item(['included' => 'thing'], function ($data) {
                 return $data;
             });
         });
-        $transformer->setDefaultIncludes(array('book'));
-        $scope = new Scope($manager, new Item(array(), $transformer));
-        $included = $transformer->processIncludedResources($scope, array('meh'));
-        $this->assertEquals(array('book' => array('data' => array('included' => 'thing'))), $included);
+        $transformer->setDefaultIncludes(['book']);
+        $scope = new Scope($manager, new Item([], $transformer));
+        $included = $transformer->processIncludedResources($scope, ['meh']);
+        $this->assertEquals(['book' => ['data' => ['included' => 'thing']]], $included);
     }
 
     /**
@@ -216,14 +216,14 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
 
         $transformer = m::mock('League\Fractal\TransformerAbstract[transform]');
         $transformer->shouldReceive('includeBook')->once()->andReturnUsing(function ($data) {
-            return new Item(array('included' => 'thing'), function ($data) {
+            return new Item(['included' => 'thing'], function ($data) {
                 return $data;
             });
         });
-        $transformer->setAvailableIncludes(array('book'));
-        $scope = new Scope($manager, new Item(array(), $transformer));
-        $included = $transformer->processIncludedResources($scope, array('meh'));
-        $this->assertEquals(array('book' => array('data' => array('included' => 'thing'))), $included);
+        $transformer->setAvailableIncludes(['book']);
+        $scope = new Scope($manager, new Item([], $transformer));
+        $included = $transformer->processIncludedResources($scope, ['meh']);
+        $this->assertEquals(['book' => ['data' => ['included' => 'thing']]], $included);
     }
 
     public function testParamBagIsProvidedForIncludes()
@@ -237,9 +237,9 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
             ->with(m::any(), m::type('\League\Fractal\ParamBag'))
             ->once();
 
-        $transformer->setAvailableIncludes(array('book'));
-        $scope = new Scope($manager, new Item(array(), $transformer));
-        $included = $transformer->processIncludedResources($scope, array());
+        $transformer->setAvailableIncludes(['book']);
+        $scope = new Scope($manager, new Item([], $transformer));
+        $included = $transformer->processIncludedResources($scope, []);
     }
 
     /**
@@ -251,10 +251,10 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
         $manager = new Manager();
         $manager->parseIncludes('book');
 
-        $collectionData = array(
-            array('included' => 'thing'),
-            array('another' => 'thing'),
-        );
+        $collectionData = [
+            ['included' => 'thing'],
+            ['another' => 'thing'],
+        ];
 
         $transformer = m::mock('League\Fractal\TransformerAbstract[transform]');
         $transformer->shouldReceive('includeBook')->once()->andReturnUsing(function ($data) use ($collectionData) {
@@ -262,10 +262,10 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
                 return $data;
             });
         });
-        $transformer->setAvailableIncludes(array('book'));
-        $scope = new Scope($manager, new Collection(array(), $transformer));
-        $included = $transformer->processIncludedResources($scope, array('meh'));
-        $this->assertEquals(array('book' => array('data' => $collectionData)), $included);
+        $transformer->setAvailableIncludes(['book']);
+        $scope = new Scope($manager, new Collection([], $transformer));
+        $included = $transformer->processIncludedResources($scope, ['meh']);
+        $this->assertEquals(['book' => ['data' => $collectionData]], $included);
     }
 
     /**
@@ -277,9 +277,9 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
         $transformer = m::mock('League\Fractal\TransformerAbstract[transform]');
         $transformer->shouldReceive('includeBook')->once()->andReturn(null);
 
-        $transformer->setDefaultIncludes(array('book'));
-        $scope = new Scope(new Manager(), new Item(array(), $transformer));
-        $included = $transformer->processIncludedResources($scope, array('meh'));
+        $transformer->setDefaultIncludes(['book']);
+        $scope = new Scope(new Manager(), new Item([], $transformer));
+        $included = $transformer->processIncludedResources($scope, ['meh']);
 
         $this->assertFalse($included);
     }
@@ -290,7 +290,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     public function testItem()
     {
         $mock = m::mock('League\Fractal\TransformerAbstract');
-        $item = $mock->item(array(), function () {
+        $item = $mock->item([], function () {
         });
         $this->assertInstanceOf('League\Fractal\Resource\Item', $item);
     }
@@ -301,7 +301,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     public function testCollection()
     {
         $mock = m::mock('League\Fractal\TransformerAbstract');
-        $collection = $mock->collection(array(), function () {
+        $collection = $mock->collection([], function () {
         });
         $this->assertInstanceOf('League\Fractal\Resource\Collection', $collection);
     }


### PR DESCRIPTION
This PR

* [x] turns arrays using long array syntax into arrays using short syntax

Follows https://twitter.com/kayladnls/status/634026175459889154.
Related to https://github.com/thephpleague/fractal/blob/master/composer.json#L21.

:information_desk_person: Of course I didn't do this manually, but used [`fabpot/php-cs-fixer`](http://github.com/FriendsOfPHP/PHP-CS-Fixer) instead.
