### PR TITLE
Fix: Also cover Scope::toJson()

### DIFF
--- a/test/ScopeTest.php
+++ b/test/ScopeTest.php
@@ -54,6 +54,27 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('data' => array('foo' => 'bar')), $scope->toArray());
     }
 
+    public function testToJson()
+    {
+        $data = [
+            'foo' => 'bar',
+        ];
+
+        $manager = new Manager();
+
+        $resource = new Item($data, function ($data) {
+            return $data;
+        });
+
+        $scope = new Scope($manager, $resource);
+
+        $expected = json_encode([
+            'data' => $data,
+        ]);
+
+        $this->assertSame($expected, $scope->toJson());
+    }
+
     public function testGetCurrentScope()
     {
         $manager = new Manager();


### PR DESCRIPTION
This PR

* [x] adds coverage for `Scope::toJson()` - because you never know