### PR TITLE
Fix: Assert sameness, not just equality

### DIFF
--- a/test/ManagerTest.php
+++ b/test/ManagerTest.php
@@ -43,19 +43,19 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         // Does a CSV string work
         $manager->parseIncludes('foo,bar');
-        $this->assertEquals(array('foo', 'bar'), $manager->getRequestedIncludes());
+        $this->assertSame(array('foo', 'bar'), $manager->getRequestedIncludes());
 
         // Does a big array of stuff work
         $manager->parseIncludes(array('foo', 'bar', 'bar.baz'));
-        $this->assertEquals(array('foo', 'bar', 'bar.baz'), $manager->getRequestedIncludes());
+        $this->assertSame(array('foo', 'bar', 'bar.baz'), $manager->getRequestedIncludes());
 
         // Are repeated things stripped
         $manager->parseIncludes(array('foo', 'foo', 'bar'));
-        $this->assertEquals(array('foo', 'bar'), $manager->getRequestedIncludes());
+        $this->assertSame(array('foo', 'bar'), $manager->getRequestedIncludes());
 
         // Do requests for `baz.bart` also request `baz`?
         $manager->parseIncludes(array('foo.bar'));
-        $this->assertEquals(array('foo', 'foo.bar'), $manager->getRequestedIncludes());
+        $this->assertSame(array('foo', 'foo.bar'), $manager->getRequestedIncludes());
 
         // See if fancy syntax works
         $manager->parseIncludes('foo:limit(5|1):order(-something):anotherparam');
@@ -64,9 +64,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('League\Fractal\ParamBag', $params);
 
-        $this->assertEquals(array('5', '1'), $params['limit']);
-        $this->assertEquals(array('-something'), $params['order']);
-        $this->assertEquals(array(''), $params['anotherparam']);
+        $this->assertSame(array('5', '1'), $params['limit']);
+        $this->assertSame(array('-something'), $params['order']);
+        $this->assertSame(array(''), $params['anotherparam']);
         $this->assertNull($params['totallymadeup']);
     }
 
@@ -76,7 +76,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         // Should limit to 10 by default
         $manager->parseIncludes('a.b.c.d.e.f.g.h.i.j.NEVER');
-        $this->assertEquals(
+        $this->assertSame(
             array(
                 'a',
                 'a.b',
@@ -95,7 +95,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         // Try setting to 3 and see what happens
         $manager->setRecursionLimit(3);
         $manager->parseIncludes('a.b.c.NEVER');
-        $this->assertEquals(
+        $this->assertSame(
             array(
                 'a',
                 'a.b',
@@ -118,8 +118,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('League\Fractal\Scope', $rootScope);
 
-        $this->assertEquals(array('data' => array('foo' => 'bar')), $rootScope->toArray());
-        $this->assertEquals('{"data":{"foo":"bar"}}', $rootScope->toJson());
+        $this->assertSame(array('data' => array('foo' => 'bar')), $rootScope->toArray());
+        $this->assertSame('{"data":{"foo":"bar"}}', $rootScope->toJson());
 
         // Collection
         $resource = new Collection(array(array('foo' => 'bar')), function (array $data) {
@@ -130,8 +130,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('League\Fractal\Scope', $rootScope);
 
-        $this->assertEquals(array('data' => array(array('foo' => 'bar'))), $rootScope->toArray());
-        $this->assertEquals('{"data":[{"foo":"bar"}]}', $rootScope->toJson());
+        $this->assertSame(array('data' => array(array('foo' => 'bar'))), $rootScope->toArray());
+        $this->assertSame('{"data":[{"foo":"bar"}]}', $rootScope->toJson());
     }
 
     public function tearDown()

--- a/test/Pagination/CursorTest.php
+++ b/test/Pagination/CursorTest.php
@@ -10,19 +10,19 @@ class CursorTest extends \PHPUnit_Framework_TestCase
     {
         $cursor = new Cursor(100, 90, 110, 10);
 
-        $this->assertEquals($cursor->getCurrent(), 100);
-        $this->assertEquals($cursor->getPrev(), 90);
-        $this->assertEquals($cursor->getNext(), 110);
-        $this->assertEquals($cursor->getCount(), 10);
+        $this->assertSame($cursor->getCurrent(), 100);
+        $this->assertSame($cursor->getPrev(), 90);
+        $this->assertSame($cursor->getNext(), 110);
+        $this->assertSame($cursor->getCount(), 10);
 
         $cursor->setCurrent(110);
         $cursor->setPrev(106);
         $cursor->setNext(114);
         $cursor->setCount(4);
 
-        $this->assertEquals($cursor->getCurrent(), 110);
-        $this->assertEquals($cursor->getPrev(), 106);
-        $this->assertEquals($cursor->getNext(), 114);
-        $this->assertEquals($cursor->getCount(), 4);
+        $this->assertSame($cursor->getCurrent(), 110);
+        $this->assertSame($cursor->getPrev(), 106);
+        $this->assertSame($cursor->getNext(), 114);
+        $this->assertSame($cursor->getCount(), 4);
     }
 }

--- a/test/Pagination/IlluminatePaginatorAdapterTest.php
+++ b/test/Pagination/IlluminatePaginatorAdapterTest.php
@@ -29,12 +29,12 @@ class IlluminatePaginatorAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('League\Fractal\Pagination\PaginatorInterface', $adapter);
         $this->assertInstanceOf('Illuminate\Contracts\Pagination\LengthAwarePaginator', $adapter->getPaginator());
 
-        $this->assertEquals($currentPage, $adapter->getCurrentPage());
-        $this->assertEquals($lastPage, $adapter->getLastPage());
-        $this->assertEquals($count, $adapter->getCount());
-        $this->assertEquals($total, $adapter->getTotal());
-        $this->assertEquals($perPage, $adapter->getPerPage());
-        $this->assertEquals('http://example.com/foo?page=1', $adapter->getUrl(1));
+        $this->assertSame($currentPage, $adapter->getCurrentPage());
+        $this->assertSame($lastPage, $adapter->getLastPage());
+        $this->assertSame($count, $adapter->getCount());
+        $this->assertSame($total, $adapter->getTotal());
+        $this->assertSame($perPage, $adapter->getPerPage());
+        $this->assertSame('http://example.com/foo?page=1', $adapter->getUrl(1));
     }
 
     public function tearDown()

--- a/test/Pagination/PagerfantaPaginatorAdapterTest.php
+++ b/test/Pagination/PagerfantaPaginatorAdapterTest.php
@@ -39,16 +39,16 @@ class PagerfantaPaginatorAdapterTest extends \PHPUnit_Framework_TestCase
             $adapter
         );
 
-        $this->assertEquals($currentPage, $adapter->getCurrentPage());
-        $this->assertEquals($lastPage, $adapter->getLastPage());
-        $this->assertEquals($count, $adapter->getCount());
-        $this->assertEquals($total, $adapter->getTotal());
-        $this->assertEquals($perPage, $adapter->getPerPage());
-        $this->assertEquals(
+        $this->assertSame($currentPage, $adapter->getCurrentPage());
+        $this->assertSame($lastPage, $adapter->getLastPage());
+        $this->assertSame($count, $adapter->getCount());
+        $this->assertSame($total, $adapter->getTotal());
+        $this->assertSame($perPage, $adapter->getPerPage());
+        $this->assertSame(
             'http://example.com/foo?page=1',
             $adapter->getUrl(1)
         );
-        $this->assertEquals(
+        $this->assertSame(
             'http://example.com/foo?page=3',
             $adapter->getUrl(3)
         );

--- a/test/Pagination/ZendFrameworkPaginatorAdapterTest.php
+++ b/test/Pagination/ZendFrameworkPaginatorAdapterTest.php
@@ -36,13 +36,13 @@ class ZendFrameworkPaginatorAdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('League\Fractal\Pagination\PaginatorInterface', $adapter);
 
-        $this->assertEquals($currentPage, $adapter->getCurrentPage());
-        $this->assertEquals($lastPage, $adapter->getLastPage());
-        $this->assertEquals($count, $adapter->getCount());
-        $this->assertEquals($total, $adapter->getTotal());
-        $this->assertEquals($perPage, $adapter->getPerPage());
-        $this->assertEquals('http://example.com/foo?page=1', $adapter->getUrl(1));
-        $this->assertEquals('http://example.com/foo?page=3', $adapter->getUrl(3));
+        $this->assertSame($currentPage, $adapter->getCurrentPage());
+        $this->assertSame($lastPage, $adapter->getLastPage());
+        $this->assertSame($count, $adapter->getCount());
+        $this->assertSame($total, $adapter->getTotal());
+        $this->assertSame($perPage, $adapter->getPerPage());
+        $this->assertSame('http://example.com/foo?page=1', $adapter->getUrl(1));
+        $this->assertSame('http://example.com/foo?page=3', $adapter->getUrl(3));
     }
 
     public function tearDown()

--- a/test/ParamBagTest.php
+++ b/test/ParamBagTest.php
@@ -8,15 +8,15 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
     {
         $params = new ParamBag(array('one' => 'potato', 'two' => 'potato2'));
 
-        $this->assertEquals('potato', $params->get('one'));
-        $this->assertEquals('potato2', $params->get('two'));
+        $this->assertSame('potato', $params->get('one'));
+        $this->assertSame('potato2', $params->get('two'));
     }
 
     public function testGettingValuesTheOldFashionedWayArray()
     {
         $params = new ParamBag(array('one' => array('potato', 'tomato')));
 
-        $this->assertEquals(array('potato', 'tomato'), $params->get('one'));
+        $this->assertSame(array('potato', 'tomato'), $params->get('one'));
     }
 
     public function testArrayAccess()
@@ -26,8 +26,8 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ArrayAccess', $params);
         $this->assertArrayHasKey('foo', $params);
         $this->assertTrue(isset($params['foo']));
-        $this->assertEquals('bar', $params['foo']);
-        $this->assertEquals('ban', $params['baz']);
+        $this->assertSame('bar', $params['foo']);
+        $this->assertSame('ban', $params['baz']);
         $this->assertNull($params['totallymadeup']);
     }
 
@@ -57,8 +57,8 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
     {
         $params = new ParamBag(array('foo' => 'bar', 'baz' => 'ban'));
 
-        $this->assertEquals('bar', $params->foo);
-        $this->assertEquals('ban', $params->baz);
+        $this->assertSame('bar', $params->foo);
+        $this->assertSame('ban', $params->baz);
         $this->assertNull($params->totallymadeup);
         $this->assertTrue(isset($params->foo));
     }

--- a/test/Resource/CollectionTest.php
+++ b/test/Resource/CollectionTest.php
@@ -17,7 +17,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
             return $data;
         });
 
-        $this->assertEquals($resource->getData(), $this->simpleCollection);
+        $this->assertSame($resource->getData(), $this->simpleCollection);
     }
 
     /**
@@ -27,7 +27,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = Mockery::mock('League\Fractal\Resource\Collection')->makePartial();
         $collection->setData('foo');
-        $this->assertEquals('foo', $collection->getData());
+        $this->assertSame('foo', $collection->getData());
     }
 
     public function testGetTransformer()
@@ -37,7 +37,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_callable($resource->getTransformer()));
 
         $resource = new Collection($this->simpleCollection, 'SomeClass');
-        $this->assertEquals($resource->getTransformer(), 'SomeClass');
+        $this->assertSame($resource->getTransformer(), 'SomeClass');
     }
 
     /**
@@ -47,7 +47,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = Mockery::mock('League\Fractal\Resource\Collection')->makePartial();
         $collection->setTransformer('foo');
-        $this->assertEquals('foo', $collection->getTransformer());
+        $this->assertSame('foo', $collection->getTransformer());
     }
 
     /**
@@ -91,10 +91,10 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = Mockery::mock('League\Fractal\Resource\Collection')->makePartial();
         $this->assertInstanceOf('League\Fractal\Resource\Collection', $collection->setMetaValue('foo', 'bar'));
-        $this->assertEquals(array('foo' => 'bar'), $collection->getMeta());
-        $this->assertEquals('bar', $collection->getMetaValue('foo'));
+        $this->assertSame(array('foo' => 'bar'), $collection->getMeta());
+        $this->assertSame('bar', $collection->getMetaValue('foo'));
         $collection->setMeta(array('baz' => 'bat'));
-        $this->assertEquals(array('baz' => 'bat'), $collection->getMeta());
+        $this->assertSame(array('baz' => 'bat'), $collection->getMeta());
     }
 
     /**
@@ -113,7 +113,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = Mockery::mock('League\Fractal\Resource\Collection')->makePartial();
         $collection->setResourceKey('foo');
-        $this->assertEquals('foo', $collection->getResourceKey());
+        $this->assertSame('foo', $collection->getResourceKey());
     }
 
     public function tearDown()

--- a/test/ScopeTest.php
+++ b/test/ScopeTest.php
@@ -22,7 +22,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         });
 
         $scope = new Scope($manager, $resource, 'book');
-        $this->assertEquals($scope->getScopeIdentifier(), 'book');
+        $this->assertSame($scope->getScopeIdentifier(), 'book');
         $childScope = $scope->embedChildScope('author', $resource);
 
         $this->assertInstanceOf('League\Fractal\Scope', $childScope);
@@ -62,7 +62,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
         $scope = new Scope($manager, $resource);
 
-        $this->assertEquals(array('data' => array('foo' => 'bar')), $scope->toArray());
+        $this->assertSame(array('data' => array('foo' => 'bar')), $scope->toArray());
     }
 
     public function testToJson()
@@ -94,13 +94,13 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         });
 
         $scope = new Scope($manager, $resource, 'book');
-        $this->assertEquals('book', $scope->getScopeIdentifier());
+        $this->assertSame('book', $scope->getScopeIdentifier());
 
         $childScope = $scope->embedChildScope('author', $resource);
-        $this->assertEquals('author', $childScope->getScopeIdentifier());
+        $this->assertSame('author', $childScope->getScopeIdentifier());
 
         $grandChildScope = $childScope->embedChildScope('profile', $resource);
-        $this->assertEquals('profile', $grandChildScope->getScopeIdentifier());
+        $this->assertSame('profile', $grandChildScope->getScopeIdentifier());
     }
 
     public function testGetIdentifier()
@@ -111,13 +111,13 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         });
 
         $scope = new Scope($manager, $resource, 'book');
-        $this->assertEquals('book', $scope->getIdentifier());
+        $this->assertSame('book', $scope->getIdentifier());
 
         $childScope = $scope->embedChildScope('author', $resource);
-        $this->assertEquals('book.author', $childScope->getIdentifier());
+        $this->assertSame('book.author', $childScope->getIdentifier());
 
         $grandChildScope = $childScope->embedChildScope('profile', $resource);
-        $this->assertEquals('book.author.profile', $grandChildScope->getIdentifier());
+        $this->assertSame('book.author.profile', $grandChildScope->getIdentifier());
     }
 
     public function testGetParentScopes()
@@ -130,10 +130,10 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $scope = new Scope($manager, $resource, 'book');
 
         $childScope = $scope->embedChildScope('author', $resource);
-        $this->assertEquals(array('book'), $childScope->getParentScopes());
+        $this->assertSame(array('book'), $childScope->getParentScopes());
 
         $grandChildScope = $childScope->embedChildScope('profile', $resource);
-        $this->assertEquals(array('book', 'author'), $grandChildScope->getParentScopes());
+        $this->assertSame(array('book', 'author'), $grandChildScope->getParentScopes());
     }
 
     public function testIsRequested()
@@ -189,7 +189,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
         $scope = new Scope($manager, $resource);
 
-        $this->assertEquals(array('data' => array('bar' => 'baz', 'book' => array('yin' => 'yang'))), $scope->toArray());
+        $this->assertSame(array('data' => array('bar' => 'baz', 'book' => array('yin' => 'yang'))), $scope->toArray());
     }
 
     public function testToArrayWithSideloadedIncludes()
@@ -223,7 +223,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
             'sideloaded' => array('book' => array('yin' => 'yang')),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
     }
 
     public function testPushParentScope()
@@ -235,11 +235,11 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
         $scope = new Scope($manager, $resource);
 
-        $this->assertEquals(1, $scope->pushParentScope('book'));
-        $this->assertEquals(2, $scope->pushParentScope('author'));
-        $this->assertEquals(3, $scope->pushParentScope('profile'));
+        $this->assertSame(1, $scope->pushParentScope('book'));
+        $this->assertSame(2, $scope->pushParentScope('author'));
+        $this->assertSame(3, $scope->pushParentScope('profile'));
 
-        $this->assertEquals(array('book', 'author', 'profile'), $scope->getParentScopes());
+        $this->assertSame(array('book', 'author', 'profile'), $scope->getParentScopes());
     }
 
     public function testRunAppropriateTransformerWithItem()
@@ -253,7 +253,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
         $resource = new Item($this->simpleItem, $transformer);
         $scope = $manager->createData($resource);
-        $this->assertEquals(array('data' => $this->simpleItem), $scope->toArray());
+        $this->assertSame(array('data' => $this->simpleItem), $scope->toArray());
     }
 
     public function testRunAppropriateTransformerWithCollection()
@@ -268,7 +268,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $resource = new Collection(array(array('foo' => 'bar')), $transformer);
         $scope = $manager->createData($resource);
 
-        $this->assertEquals(array('data' => array(array('foo' => 'bar'))), $scope->toArray());
+        $this->assertSame(array('data' => array(array('foo' => 'bar'))), $scope->toArray());
     }
 
     /**
@@ -316,6 +316,12 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $rootScope = $manager->createData($collection);
 
         $expectedOutput = array(
+            'data' => array(
+                array(
+                    'foo' => 'bar',
+                    'baz' => 'ban',
+                ),
+            ),
             'meta' => array(
                 'pagination' => array(
                     'total' => $total,
@@ -329,15 +335,9 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
             ),
-            'data' => array(
-                array(
-                    'foo' => 'bar',
-                    'baz' => 'ban',
-                ),
-            ),
         );
 
-        $this->assertEquals($expectedOutput, $rootScope->toArray());
+        $this->assertSame($expectedOutput, $rootScope->toArray());
     }
 
     public function testCursorOutput()
@@ -362,6 +362,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $rootScope = $manager->createData($collection);
 
         $expectedOutput = array(
+            'data' => $inputData,
             'meta' => array(
                 'cursor' => array(
                     'current' => 0,
@@ -370,10 +371,9 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
                     'count' => 2,
                 ),
             ),
-            'data' => $inputData,
         );
 
-        $this->assertEquals($expectedOutput, $rootScope->toArray());
+        $this->assertSame($expectedOutput, $rootScope->toArray());
     }
 
     public function testDefaultIncludeSuccess()
@@ -394,7 +394,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
     }
 
     public function tearDown()

--- a/test/Serializer/ArraySerializerTest.php
+++ b/test/Serializer/ArraySerializerTest.php
@@ -53,7 +53,7 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         // Same again with meta
         $resource->setMetaValue('foo', 'bar');
@@ -71,7 +71,7 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
     }
 
     public function testSerializingCollectionResource()
@@ -104,11 +104,11 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         // JSON array of JSON objects
         $expectedJson = '{"books":[{"title":"Foo","year":1991,"author":{"name":"Dave"}},{"title":"Bar","year":1997,"author":{"name":"Bob"}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
 
         // Same again with metadata
         $resource->setMetaValue('foo', 'bar');
@@ -137,10 +137,10 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"books":[{"title":"Foo","year":1991,"author":{"name":"Dave"}},{"title":"Bar","year":1997,"author":{"name":"Bob"}}],"meta":{"foo":"bar"}}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingCollectionResourceWithoutName()
@@ -156,7 +156,7 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
 
         // JSON array of JSON objects
         $expectedJson = '{"data":[{"title":"Foo","year":1991,"author":{"name":"Dave"}},{"title":"Bar","year":1997,"author":{"name":"Bob"}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
 
         // Same again with metadata
         $resource->setMetaValue('foo', 'bar');
@@ -164,7 +164,7 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
         $scope = new Scope($manager, $resource);
 
         $expectedJson = '{"data":[{"title":"Foo","year":1991,"author":{"name":"Dave"}},{"title":"Bar","year":1997,"author":{"name":"Bob"}}],"meta":{"foo":"bar"}}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function tearDown()

--- a/test/Serializer/DataArraySerializerTest.php
+++ b/test/Serializer/DataArraySerializerTest.php
@@ -39,7 +39,7 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         // Same again with metadata
         $resource = new Item($bookData, new GenericBookTransformer(), 'book');
@@ -48,9 +48,6 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
         $scope = new Scope($manager, $resource);
 
         $expected = array(
-            'meta' => array(
-                'foo' => 'bar',
-            ),
             'data' => array(
                 'title' => 'Foo',
                 'year' => 1991,
@@ -60,9 +57,12 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
                     ),
                 ),
             ),
+            'meta' => array(
+                'foo' => 'bar',
+            ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
     }
 
     public function testSerializingCollectionResource()
@@ -116,10 +116,10 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":[{"title":"Foo","year":1991,"author":{"data":{"name":"Dave"}}},{"title":"Bar","year":1997,"author":{"data":{"name":"Bob"}}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
 
         // Same again with meta
         $resource = new Collection($booksData, new GenericBookTransformer(), 'book');
@@ -128,9 +128,6 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
         $scope = new Scope($manager, $resource);
 
         $expected = array(
-            'meta' => array(
-                'foo' => 'bar',
-            ),
             'data' => array(
                 array(
                     'title' => 'Foo',
@@ -151,12 +148,15 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
                     ),
                 ),
             ),
+            'meta' => array(
+                'foo' => 'bar',
+            ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":[{"title":"Foo","year":1991,"author":{"data":{"name":"Dave"}}},{"title":"Bar","year":1997,"author":{"data":{"name":"Bob"}}}],"meta":{"foo":"bar"}}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function tearDown()

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -64,10 +64,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"relationships":{"author":{"data":{"type":"people","id":"1"}}}},"included":[{"type":"people","id":"1","attributes":{"name":"Dave"}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingItemResourceWithEmptyHasOneInclude()
@@ -101,10 +101,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"relationships":{"author":{"data":null}}}}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingItemResourceWithHasManyInclude()
@@ -177,7 +177,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $scope->toArray());
 
         $expectedJson = '{"data":{"type":"people","id":"1","attributes":{"name":"Dave"},"relationships":{"published":{"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},"included":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingItemResourceWithEmptyHasManyInclude()
@@ -209,10 +209,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":{"type":"people","id":"1","attributes":{"name":"Dave"},"relationships":{"published":{"data":[]}}}}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingItemResourceWithoutIncludes()
@@ -242,10 +242,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991}}}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingItemResourceWithMeta()
@@ -279,10 +279,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991}},"meta":{"foo":"bar"}}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingCollectionResourceWithoutIncludes()
@@ -332,10 +332,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingCollectionResourceWithHasOneInclude()
@@ -419,10 +419,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"relationships":{"author":{"data":{"type":"people","id":"1"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"relationships":{"author":{"data":{"type":"people","id":"2"}}}}],"included":[{"type":"people","id":"1","attributes":{"name":"Dave"}},{"type":"people","id":"2","attributes":{"name":"Bob"}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingCollectionResourceWithEmptyHasOneInclude()
@@ -493,10 +493,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"relationships":{"author":{"data":null}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"relationships":{"author":{"data":{"type":"people","id":"2"}}}}],"included":[{"type":"people","id":"2","attributes":{"name":"Bob"}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingCollectionResourceWithHasManyInclude()
@@ -625,7 +625,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $scope->toArray());
 
         $expectedJson = '{"data":[{"type":"people","id":"1","attributes":{"name":"Dave"},"relationships":{"published":{"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},{"type":"people","id":"2","attributes":{"name":"Bob"},"relationships":{"published":{"data":[{"type":"books","id":"3"},{"type":"books","id":"4"}]}}}],"included":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015}},{"type":"books","id":"3","attributes":{"title":"Baz","year":1995}},{"type":"books","id":"4","attributes":{"title":"Quux","year":2000}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingCollectionResourceWithEmptyHasManyInclude()
@@ -701,7 +701,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $scope->toArray());
 
         $expectedJson = '{"data":[{"type":"people","id":"1","attributes":{"name":"Dave"},"relationships":{"published":{"data":[]}}},{"type":"people","id":"2","attributes":{"name":"Bob"},"relationships":{"published":{"data":[{"type":"books","id":"3"}]}}}],"included":[{"type":"books","id":"3","attributes":{"title":"Baz","year":1995}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingCollectionResourceWithMeta()
@@ -754,10 +754,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997}}],"meta":{"foo":"bar"}}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingCollectionResourceWithDuplicatedIncludeData()
@@ -834,10 +834,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"relationships":{"author":{"data":{"type":"people","id":"1"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"relationships":{"author":{"data":{"type":"people","id":"1"}}}}],"included":[{"type":"people","id":"1","attributes":{"name":"Dave"}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingItemResourceWithNestedIncludes()
@@ -920,10 +920,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"relationships":{"author":{"data":{"type":"people","id":"1"}}}},"included":[{"type":"books","id":"2","attributes":{"title":"Bar","year":2015}},{"type":"people","id":"1","attributes":{"name":"Dave"},"relationships":{"published":{"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingItemResourceWithSelfLink()
@@ -959,10 +959,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"}}}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingCollectionResourceWithSelfLink()
@@ -1021,10 +1021,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingItemResourceWithLinksForHasOneRelationship()
@@ -1088,7 +1088,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $scope->toArray());
 
         $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"},"data":{"type":"people","id":"1"}}}},"included":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingItemResourceWithLinksForHasManyRelationship()
@@ -1176,7 +1176,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $scope->toArray());
 
         $expectedJson = '{"data":{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},"included":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015},"links":{"self":"http:\/\/example.com\/books\/2"}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     /**
@@ -1269,10 +1269,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":{"type":"people","id":"1","attributes":{"name":"Dave"},"relationships":{"published":{"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},"included":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"relationships":{"author":{"data":{"type":"people","id":"1"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015},"relationships":{"author":{"data":{"type":"people","id":"1"}}}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function testSerializingCollectionWithReferenceToRootObjects()
@@ -1381,10 +1381,10 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expected, $scope->toArray());
+        $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"relationships":{"author":{"data":{"type":"people","id":"1"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015},"relationships":{"author":{"data":{"type":"people","id":"1"}}}}],"included":[{"type":"people","id":"1","attributes":{"name":"Dave"},"relationships":{"published":{"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}}]}';
-        $this->assertEquals($expectedJson, $scope->toJson());
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     public function tearDown()

--- a/test/TransformerAbstractTest.php
+++ b/test/TransformerAbstractTest.php
@@ -24,7 +24,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     {
         $transformer = m::mock('League\Fractal\TransformerAbstract')->makePartial();
         $transformer->setAvailableIncludes(array('foo', 'bar'));
-        $this->assertEquals(array('foo', 'bar'), $transformer->getAvailableIncludes());
+        $this->assertSame(array('foo', 'bar'), $transformer->getAvailableIncludes());
     }
 
     /**
@@ -43,7 +43,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     {
         $transformer = m::mock('League\Fractal\TransformerAbstract')->makePartial();
         $transformer->setDefaultIncludes(array('foo', 'bar'));
-        $this->assertEquals(array('foo', 'bar'), $transformer->getDefaultIncludes());
+        $this->assertSame(array('foo', 'bar'), $transformer->getDefaultIncludes());
     }
 
     /**
@@ -66,7 +66,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
         $manager = new Manager();
         $scope = new Scope($manager, m::mock('League\Fractal\Resource\ResourceAbstract'));
         $transformer->setCurrentScope($scope);
-        $this->assertEquals($transformer->getCurrentScope(), $scope);
+        $this->assertSame($transformer->getCurrentScope(), $scope);
     }
 
     public function testProcessEmbeddedResourcesNoAvailableIncludes()
@@ -145,7 +145,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
         $transformer->setAvailableIncludes(array('book', 'publisher'));
         $scope = new Scope($manager, new Item(array(), $transformer));
         $included = $transformer->processIncludedResources($scope, array('meh'));
-        $this->assertEquals(array('book' => array('data' => array('included' => 'thing'))), $included);
+        $this->assertSame(array('book' => array('data' => array('included' => 'thing'))), $included);
     }
 
     /**
@@ -202,7 +202,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
         $transformer->setDefaultIncludes(array('book'));
         $scope = new Scope($manager, new Item(array(), $transformer));
         $included = $transformer->processIncludedResources($scope, array('meh'));
-        $this->assertEquals(array('book' => array('data' => array('included' => 'thing'))), $included);
+        $this->assertSame(array('book' => array('data' => array('included' => 'thing'))), $included);
     }
 
     /**
@@ -223,7 +223,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
         $transformer->setAvailableIncludes(array('book'));
         $scope = new Scope($manager, new Item(array(), $transformer));
         $included = $transformer->processIncludedResources($scope, array('meh'));
-        $this->assertEquals(array('book' => array('data' => array('included' => 'thing'))), $included);
+        $this->assertSame(array('book' => array('data' => array('included' => 'thing'))), $included);
     }
 
     public function testParamBagIsProvidedForIncludes()
@@ -265,7 +265,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
         $transformer->setAvailableIncludes(array('book'));
         $scope = new Scope($manager, new Collection(array(), $transformer));
         $included = $transformer->processIncludedResources($scope, array('meh'));
-        $this->assertEquals(array('book' => array('data' => $collectionData)), $included);
+        $this->assertSame(array('book' => array('data' => $collectionData)), $included);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] uses `assertSame()` instead of `assertEquals()` because we can afford a bit of strictness here