### PR TITLE
Fix: Only collect and report coverage once

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,4 +20,3 @@ checks:
 tools:
     external_code_coverage:
         timeout: 1800
-        runs: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 language: php
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7
-  - hhvm
+matrix:
+  include:
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+      env: COLLECT_COVERAGE=true
+    - php: 7
+    - php: hhvm
 
 install:
   - travis_retry composer install --no-interaction --prefer-source
 
 script:
-  - if [[ $TRAVIS_PHP_VERSION == 'hhvm' || $TRAVIS_PHP_VERSION == '7' ]]; then vendor/bin/phpunit; fi
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7' ]]; then vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover; fi
+  - if [[ "$COLLECT_COVERAGE" == "true" ]]; then vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover; else vendor/bin/phpunit --no-coverage; fi
 
 after_script:
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7' ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7' ]]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - if [[ "$COLLECT_COVERAGE" == "true" ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi


### PR DESCRIPTION
This PR

* [x] collects and reports code coverage only on PHP5.6

:information_desk_person: This speeds up builds, and I believe (guess) that Scrutinizer only accepts the first submission for a build anyway (does it?), see https://scrutinizer-ci.com/docs/tools/external-code-coverage/.