### PR TITLE
Fix: Typos

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -167,7 +167,7 @@ class Manager
             }
 
             // Matches multiple instances of 'something(foo|bar|baz)' in the string
-            // I guess it ignores : so you could use anything, but probably dont do that
+            // I guess it ignores : so you could use anything, but probably don't do that
             preg_match_all('/([\w]+)\(([^\)]+)\)/', $allModifiersStr, $allModifiersArr);
 
             // [0] is full matched strings...

--- a/src/Pagination/Cursor.php
+++ b/src/Pagination/Cursor.php
@@ -41,7 +41,7 @@ class Cursor implements CursorInterface
     protected $next;
 
     /**
-     * Items being holded for the current cursor position.
+     * Items being held for the current cursor position.
      *
      * @var int
      */

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -34,7 +34,7 @@ class Scope
     /**
      * @var string
      */
-    protected $scopeIdentifer;
+    protected $scopeIdentifier;
 
     /**
      * @var \League\Fractal\Manager
@@ -56,19 +56,19 @@ class Scope
      *
      * @param Manager           $manager
      * @param ResourceInterface $resource
-     * @param string            $scopeIdentifer
+     * @param string            $scopeIdentifier
      *
      * @return void
      */
-    public function __construct(Manager $manager, ResourceInterface $resource, $scopeIdentifer = null)
+    public function __construct(Manager $manager, ResourceInterface $resource, $scopeIdentifier = null)
     {
         $this->manager = $manager;
         $this->resource = $resource;
-        $this->scopeIdentifer = $scopeIdentifer;
+        $this->scopeIdentifier = $scopeIdentifier;
     }
 
     /**
-     * Embed a scope as a child of the currenct scope.
+     * Embed a scope as a child of the current scope.
      *
      * @internal
      *
@@ -89,7 +89,7 @@ class Scope
      */
     public function getScopeIdentifier()
     {
-        return $this->scopeIdentifer;
+        return $this->scopeIdentifier;
     }
 
     /**
@@ -101,7 +101,7 @@ class Scope
      */
     public function getIdentifier($appendIdentifier = null)
     {
-        $identifierParts = array_merge($this->parentScopes, array($this->scopeIdentifer, $appendIdentifier));
+        $identifierParts = array_merge($this->parentScopes, array($this->scopeIdentifier, $appendIdentifier));
 
         return implode('.', array_filter($identifierParts));
     }
@@ -143,7 +143,7 @@ class Scope
     {
         if ($this->parentScopes) {
             $scopeArray = array_slice($this->parentScopes, 1);
-            array_push($scopeArray, $this->scopeIdentifer, $checkScopeSegment);
+            array_push($scopeArray, $this->scopeIdentifier, $checkScopeSegment);
         } else {
             $scopeArray = array($checkScopeSegment);
         }


### PR DESCRIPTION
This PR

* [x] fixes a bunch of typos in docblocks and variable names