### PR TITLE
Fix: Add missing arguments to docblocks

### DIFF
--- a/src/Pagination/Cursor.php
+++ b/src/Pagination/Cursor.php
@@ -51,6 +51,7 @@ class Cursor implements CursorInterface
      * Create a new Cursor instance.
      *
      * @param int   $current
+     * @param null  $prev
      * @param mixed $next
      * @param int   $count
      *

--- a/src/ParamBag.php
+++ b/src/ParamBag.php
@@ -73,6 +73,7 @@ class ParamBag implements \ArrayAccess
      * Disallow changing the value of params in the data bag via property access.
      *
      * @param string $key
+     * @param mixed  $value
      *
      * @throws \LogicException
      *
@@ -125,6 +126,7 @@ class ParamBag implements \ArrayAccess
      * Disallow changing the value of params in the data bag via array access.
      *
      * @param string $key
+     * @param mixed  $value
      *
      * @throws \LogicException
      *


### PR DESCRIPTION
This PR

* [x] adds missing arguments to docblocks