### PR TITLE
Fix: Assert that meta can be mutated / accessed

### DIFF
--- a/test/Resource/ItemTest.php
+++ b/test/Resource/ItemTest.php
@@ -42,4 +42,20 @@ class ItemTest extends \PHPUnit_Framework_TestCase
         $collection->setResourceKey('foo');
         $this->assertEquals('foo', $collection->getResourceKey());
     }
+
+    public function testCanSetAndGetMeta()
+    {
+        $meta = array(
+            'foo' => 'bar',
+            'bar' => [
+                'baz' => 'qux',
+            ],
+        );
+
+        $item = new Item();
+
+        $item->setMeta($meta);
+
+        $this->assertSame($meta, $item->getMeta());
+    }
 }


### PR DESCRIPTION
This  PR

* [x] also asserts that meta data can be mutated / accessed

:person_with_pouting_face: Not sure that I understand the excessive use of Mockery in tests where we actually want to assert the behaviour of the SUT. 