### PR TITLE
Fix: Clean up Item test

### DIFF
--- a/test/Resource/ItemTest.php
+++ b/test/Resource/ItemTest.php
@@ -9,21 +9,21 @@ class ItemTest extends \PHPUnit_Framework_TestCase
 
     public function testGetData()
     {
-        $resource = new Item($this->simpleItem, function () {});
+        $item = new Item($this->simpleItem, function () {});
 
-        $this->assertEquals($resource->getData(), $this->simpleItem);
+        $this->assertEquals($item->getData(), $this->simpleItem);
     }
 
     public function testGetTransformer()
     {
-        $resource = new Item($this->simpleItem, function () {});
+        $item = new Item($this->simpleItem, function () {});
 
-        $this->assertTrue(is_callable($resource->getTransformer()));
+        $this->assertTrue(is_callable($item->getTransformer()));
 
         $transformer = 'thismightbeacallablestring';
-        $resource = new Item($this->simpleItem, $transformer);
+        $item = new Item($this->simpleItem, $transformer);
 
-        $this->assertEquals($resource->getTransformer(), $transformer);
+        $this->assertEquals($item->getTransformer(), $transformer);
     }
 
     /**
@@ -31,9 +31,9 @@ class ItemTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetResourceKey()
     {
-        $collection = Mockery::mock('League\Fractal\Resource\Item')->makePartial();
-        
-        $this->assertInstanceOf('League\Fractal\Resource\Item', $collection->setResourceKey('foo'));
+        $item = Mockery::mock('League\Fractal\Resource\Item')->makePartial();
+
+        $this->assertInstanceOf('League\Fractal\Resource\Item', $item->setResourceKey('foo'));
     }
 
     /**
@@ -41,9 +41,9 @@ class ItemTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetResourceKey()
     {
-        $collection = Mockery::mock('League\Fractal\Resource\Item')->makePartial();
-        $collection->setResourceKey('foo');
+        $item = Mockery::mock('League\Fractal\Resource\Item')->makePartial();
+        $item->setResourceKey('foo');
 
-        $this->assertEquals('foo', $collection->getResourceKey());
+        $this->assertEquals('foo', $item->getResourceKey());
     }
 }

--- a/test/Resource/ItemTest.php
+++ b/test/Resource/ItemTest.php
@@ -11,7 +11,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase
     {
         $item = new Item($this->simpleItem, function () {});
 
-        $this->assertEquals($item->getData(), $this->simpleItem);
+        $this->assertSame($item->getData(), $this->simpleItem);
     }
 
     public function testGetTransformer()
@@ -23,7 +23,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase
         $transformer = 'thismightbeacallablestring';
         $item = new Item($this->simpleItem, $transformer);
 
-        $this->assertEquals($item->getTransformer(), $transformer);
+        $this->assertSame($item->getTransformer(), $transformer);
     }
 
     /**
@@ -44,6 +44,6 @@ class ItemTest extends \PHPUnit_Framework_TestCase
         $item = Mockery::mock('League\Fractal\Resource\Item')->makePartial();
         $item->setResourceKey('foo');
 
-        $this->assertEquals('foo', $item->getResourceKey());
+        $this->assertSame('foo', $item->getResourceKey());
     }
 }

--- a/test/Resource/ItemTest.php
+++ b/test/Resource/ItemTest.php
@@ -10,17 +10,19 @@ class ItemTest extends \PHPUnit_Framework_TestCase
     public function testGetData()
     {
         $resource = new Item($this->simpleItem, function () {});
+
         $this->assertEquals($resource->getData(), $this->simpleItem);
     }
 
     public function testGetTransformer()
     {
-        $resource = new Item($this->simpleItem, function () {
-        });
+        $resource = new Item($this->simpleItem, function () {});
+
         $this->assertTrue(is_callable($resource->getTransformer()));
 
         $transformer = 'thismightbeacallablestring';
         $resource = new Item($this->simpleItem, $transformer);
+
         $this->assertEquals($resource->getTransformer(), $transformer);
     }
 
@@ -30,6 +32,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase
     public function testSetResourceKey()
     {
         $collection = Mockery::mock('League\Fractal\Resource\Item')->makePartial();
+        
         $this->assertInstanceOf('League\Fractal\Resource\Item', $collection->setResourceKey('foo'));
     }
 
@@ -40,6 +43,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase
     {
         $collection = Mockery::mock('League\Fractal\Resource\Item')->makePartial();
         $collection->setResourceKey('foo');
+
         $this->assertEquals('foo', $collection->getResourceKey());
     }
 }

--- a/test/Resource/ItemTest.php
+++ b/test/Resource/ItemTest.php
@@ -33,7 +33,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase
     {
         $item = Mockery::mock('League\Fractal\Resource\Item')->makePartial();
 
-        $this->assertInstanceOf('League\Fractal\Resource\Item', $item->setResourceKey('foo'));
+        $this->assertSame($item, $item->setResourceKey('foo'));
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] gives code a bit of room to breathe 
* [x] renames variables 
* [x] asserts sameness, not just equality
* [x] properly asserts fluent interface

:information_desk_person: Vertical whitespace helps - also, we're testing the behaviour of `League\Fractal\Resource\Item` here, right?