### PR TITLE
Fix inclusion of root objects into sideloaded array in JsonApiSerializer

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -215,7 +215,7 @@ class Scope
                 // the objects that are sideloaded, it can do so now.
                 $includedData = $serializer->filterIncludes(
                     $includedData,
-                    $this->resource
+                    $data
                 );
             }
 

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -112,11 +112,11 @@ abstract class SerializerAbstract
      * Hook for the serializer to modify the final list of includes.
      *
      * @param array             $includedData
-     * @param ResourceInterface $resource
+     * @param array             $data
      *
      * @return array
      */
-    public function filterIncludes($includedData, ResourceInterface $resource)
+    public function filterIncludes($includedData, $data)
     {
         return $includedData;
     }


### PR DESCRIPTION
Additionally, this will fix any errors encountered when transforming objects instead of arrays. See [this comment](https://github.com/thephpleague/fractal/pull/205#issuecomment-136124723). 

Previously the serializer used the rawData (i.e. untransformed) to filter the root objects from the sideloads. Now it uses the transformed data, therefore it always is an array.