### PR TITLE
Allows dasherized includes for JSONAPI Serializer

### DIFF
--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -173,7 +173,7 @@ abstract class TransformerAbstract
         $params = $scope->getManager()->getIncludeParams($scopeIdentifier);
 
         // Check if the method name actually exists
-        $methodName = 'include'.str_replace(' ', '', ucwords(str_replace('_', ' ', $includeName)));
+        $methodName = 'include'.str_replace(' ', '', ucwords(str_replace('_', ' ', str_replace('-', ' ', $includeName))));
 
         $resource = call_user_func([$this, $methodName], $data, $params);
 

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -70,6 +70,62 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
+    public function testSerializingItemResourceWithHasOneDasherizedInclude()
+    {
+        $this->manager->parseIncludes('co-author');
+
+        $bookData = [
+            'id' => 1,
+            'title' => 'Foo',
+            'year' => '1991',
+            '_author' => [
+                'id' => 1,
+                'name' => 'Dave',
+            ],
+            '_co_author' => [
+                'id' => 2,
+                'name' => 'Jim',
+            ],
+        ];
+
+        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+
+        $scope = new Scope($this->manager, $resource);
+
+        $expected = [
+            'data' => [
+                'type' => 'books',
+                'id' => '1',
+                'attributes' => [
+                    'title' => 'Foo',
+                    'year' => 1991,
+                ],
+                'relationships' => [
+                    'co-author' => [
+                        'data' => [
+                            'type' => 'people',
+                            'id' => '2',
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
+                    'type' => 'people',
+                    'id' => '2',
+                    'attributes' => [
+                        'name' => 'Jim',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $scope->toArray());
+
+        $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"relationships":{"co-author":{"data":{"type":"people","id":"2"}}}},"included":[{"type":"people","id":"2","attributes":{"name":"Jim"}}]}';
+        $this->assertSame($expectedJson, $scope->toJson());
+    }
+
     public function testSerializingItemResourceWithEmptyHasOneInclude()
     {
         $this->manager->parseIncludes('author');

--- a/test/Stub/Transformer/JsonApiBookTransformer.php
+++ b/test/Stub/Transformer/JsonApiBookTransformer.php
@@ -6,12 +6,14 @@ class JsonApiBookTransformer extends TransformerAbstract
 {
     protected $availableIncludes = [
         'author',
+        'co-author',
     ];
 
     public function transform(array $book)
     {
         $book['year'] = (int) $book['year'];
         unset($book['_author']);
+        unset($book['_co_author']);
 
         return $book;
     }
@@ -27,5 +29,18 @@ class JsonApiBookTransformer extends TransformerAbstract
         }
 
         return $this->item($book['_author'], new JsonApiAuthorTransformer(), 'people');
+    }
+
+    public function includeCoAuthor(array $book)
+    {
+        if (!array_key_exists('_co_author', $book)) {
+            return;
+        }
+
+        if ($book['_co_author'] === null) {
+            return $this->null();
+        }
+
+        return $this->item($book['_co_author'], new JsonApiAuthorTransformer(), 'people');
     }
 }


### PR DESCRIPTION
For the JSON API specification recommends hyphens as separators for attribute and relationship names.

However the current version of Fractal only allows underscore and camelCase includes.

This fixes this by allowing includes to use `-` as separators as well for related models.

This includes a test with a new relationship for `co-author` on `JsonApiBookTransformer`.