### PR TITLE
Fix issue including relationships on collections

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -263,7 +263,7 @@ class JsonApiSerializer extends ArraySerializer
     {
         $relationships = [];
 
-        foreach ($includedData as $inclusion) {
+        foreach ($includedData as $key => $inclusion) {
             foreach ($inclusion as $includeKey => $includeObject)
             {
                 if (!array_key_exists($includeKey, $relationships)) {
@@ -297,7 +297,7 @@ class JsonApiSerializer extends ArraySerializer
                     ];
                 }
 
-                $relationships[$includeKey][] = $relationship;
+                $relationships[$includeKey][$key] = $relationship;
             }
         }
 


### PR DESCRIPTION
Retaining the key that the relationship has to the data it's included with, or if the relationship does not exist for that object then the relationship is pushed up when fillRelationships() is called