### PR TITLE
Allow default / available, requested includes to be excluded

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -32,6 +32,13 @@ class Manager
     protected $requestedIncludes = [];
 
     /**
+     * Array of scope identifiers for resources to exclude.
+     *
+     * @var array
+     */
+    protected $requestedExcludes = [];
+
+    /**
      * Array containing modifiers as keys and an array value of params.
      *
      * @var array
@@ -115,6 +122,16 @@ class Manager
     }
 
     /**
+     * Get Requested Excludes.
+     *
+     * @return array
+     */
+    public function getRequestedExcludes()
+    {
+        return $this->requestedExcludes;
+    }
+
+    /**
      * Get Serializer.
      *
      * @return SerializerAbstract
@@ -191,6 +208,40 @@ class Manager
 
         // This should be optional and public someday, but without it includes would never show up
         $this->autoIncludeParents();
+
+        return $this;
+    }
+
+    /**
+     * Parse Exclude String.
+     *
+     * @param array|string $excludes Array or csv string of resources to exclude
+     *
+     * @return $this
+     */
+    public function parseExcludes($excludes)
+    {
+        $this->requestedExcludes = [];
+
+        if (is_string($excludes)) {
+            $excludes = explode(',', $excludes);
+        }
+
+        if (! is_array($excludes)) {
+            throw new \InvalidArgumentException(
+                'The parseExcludes() method expects a string or an array. '.gettype($excludes).' given'
+            );
+        }
+
+        foreach ($excludes as $excludeName) {
+            $excludeName = $this->trimToAcceptableRecursionLevel($excludeName);
+
+            if (in_array($excludeName, $this->requestedExcludes)) {
+                continue;
+            }
+
+            $this->requestedExcludes[] = $excludeName;
+        }
 
         return $this;
     }

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -161,9 +161,35 @@ class Scope
 
         $scopeString = implode('.', (array) $scopeArray);
 
-        $checkAgainstArray = $this->manager->getRequestedIncludes();
+        return in_array($scopeString, $this->manager->getRequestedIncludes());
+    }
 
-        return in_array($scopeString, $checkAgainstArray);
+    /**
+     * Is Excluded.
+     *
+     * Check if - in relation to the current scope - this specific segment should
+     * be excluded. That means, if a.b.c is excluded and the current scope is a.b,
+     * then c will not be allowed in the transformation whether it appears in
+     * the list of default or available, requested includes.
+     *
+     * @internal
+     *
+     * @param string $checkScopeSegment
+     *
+     * @return bool
+     */
+    public function isExcluded($checkScopeSegment)
+    {
+        if ($this->parentScopes) {
+            $scopeArray = array_slice($this->parentScopes, 1);
+            array_push($scopeArray, $this->scopeIdentifier, $checkScopeSegment);
+        } else {
+            $scopeArray = [$checkScopeSegment];
+        }
+
+        $scopeString = implode('.', (array) $scopeArray);
+
+        return in_array($scopeString, $this->manager->getRequestedExcludes());
     }
 
     /**

--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -89,9 +89,16 @@ abstract class TransformerAbstract
     private function figureOutWhichIncludes(Scope $scope)
     {
         $includes = $this->getDefaultIncludes();
+
         foreach ($this->getAvailableIncludes() as $include) {
             if ($scope->isRequested($include)) {
                 $includes[] = $include;
+            }
+        }
+
+        foreach ($includes as $include) {
+            if ($scope->isExcluded($include)) {
+              $includes = array_diff($includes, [$include]);
             }
         }
 

--- a/test/ManagerTest.php
+++ b/test/ManagerTest.php
@@ -74,6 +74,58 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($params['totallymadeup']);
     }
 
+        public function testParseExcludeSelfie()
+    {
+        $manager = new Manager();
+
+        // Test that some excludes provided returns self
+        $this->assertInstanceOf(get_class($manager), $manager->parseExcludes(['foo']));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The parseExcludes() method expects a string or an array. NULL given
+     */
+    public function testInvalidParseExclude()
+    {
+        $manager = new Manager();
+
+        $manager->parseExcludes(null);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The parseExcludes() method expects a string or an array. integer given
+     */
+    public function testIceTParseExclude()
+    {
+        $manager = new Manager();
+
+        $manager->parseExcludes(99);
+    }
+
+    public function testParseExcludes()
+    {
+        $manager = new Manager();
+
+        // Does a CSV string work
+        $manager->parseExcludes('foo,bar');
+
+        $this->assertSame(['foo', 'bar'], $manager->getRequestedExcludes());
+
+        // Does a big array of stuff work
+        $manager->parseExcludes(['foo', 'bar', 'bar.baz']);
+        $this->assertSame(['foo', 'bar', 'bar.baz'], $manager->getRequestedExcludes());
+
+        // Are repeated things stripped
+        $manager->parseExcludes(['foo', 'foo', 'bar']);
+        $this->assertSame(['foo', 'bar'], $manager->getRequestedExcludes());
+
+        // Do requests for `baz.bart` also request `baz`?
+        $manager->parseExcludes(['foo.bar']);
+        $this->assertSame(['foo.bar'], $manager->getRequestedExcludes());
+    }
+
     public function testRecursionLimiting()
     {
         $manager = new Manager();

--- a/test/ScopeTest.php
+++ b/test/ScopeTest.php
@@ -158,6 +158,26 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($childScope->isRequested('baz'));
     }
 
+    public function testIsExcluded()
+    {
+        $manager = new Manager();
+        $manager->parseIncludes(['foo', 'bar', 'baz.bart']);
+
+        $scope = new Scope($manager, Mockery::mock('League\Fractal\Resource\ResourceAbstract'));
+        $childScope = $scope->embedChildScope('baz', Mockery::mock('League\Fractal\Resource\ResourceAbstract'));
+
+        $manager->parseExcludes('bar');
+
+        $this->assertFalse($scope->isExcluded('foo'));
+        $this->assertTrue($scope->isExcluded('bar'));
+        $this->assertFalse($scope->isExcluded('baz.bart'));
+
+        $manager->parseExcludes('baz.bart');
+
+        $this->assertFalse($scope->isExcluded('baz'));
+        $this->assertTrue($scope->isExcluded('baz.bart'));
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */
@@ -190,7 +210,6 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $resource = new Item(['bar' => 'baz'], $transformer);
 
         $scope = new Scope($manager, $resource);
-
 
         $this->assertSame(['data' => ['bar' => 'baz', 'book' => ['yin' => 'yang']]], $scope->toArray());
     }


### PR DESCRIPTION
Project requirements periodically mandate a nested Resource specified on a Transformer's `$defaultIncludes` property be omitted.

When a book should be accompanied by it's publisher during transformation to JSON the majority of the time, I have a `BookTransformer` like this.

```php
use League/Fractal/TransformerAbstract

class BookTransformer extends TransformerAbstract 
{
    protected $defaultIncludes = [ 'publisher' ]; 

    public function transform(Book $book)
    {
        // ...
    }

    public function includePublisher(Book $book)
    {
        // ...
    }
}
```

For the times the publisher should be omitted, I have been subclassing the `BookTransformer`, resetting the `$defaultIncludes` property.

```php
use League/Fractal/TransformerAbstract

class BookTransformerWithoutPublisher extends TransformerAbstract 
{
    protected $defaultIncludes = [ ]; 
}
```

__This PR adds a `parseExcludes()` method to the Manager that accepts a string or array similar to `parseIncludes()`, without support for modifiers. This provides the ability to omit the resources on the `BookTransformer` through the Manager instead of needing the subclass.__

```php
    $manager = new League\Fractal\Manager;
    $resource = new Fractal\Resource\Item($book, new BookTransformer);

    $manager->parseExcludes('publisher');

    echo $manager->createData($resource)->toJson(); // book JSON without nested 'publisher' resource
```

The list of excludes provided to the manager will prevent both default includes and available, requested includes from being included in the transformation.

--------------------

I will happily send a PR for docs if there is interest in this functionality.