### PR TITLE
Included relationship data count should match original data

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -298,6 +298,9 @@ class JsonApiSerializer extends ArraySerializer
     {
         if ($this->isCollection($data)) {
             foreach ($relationships as $key => $relationship) {
+                if (count($data['data']) !== count($relationship)) {
+                    throw(new \Exception(sprintf('Included data count for %s does not match original data count.', $key)));
+                }
                 foreach ($relationship as $index => $relationshipData) {
                     $data['data'][$index]['relationships'][$key] = $relationshipData;
                 }

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -7,6 +7,7 @@ use League\Fractal\Scope;
 use League\Fractal\Serializer\JsonApiSerializer;
 use League\Fractal\Test\Stub\Transformer\JsonApiBookTransformer;
 use League\Fractal\Test\Stub\Transformer\JsonApiAuthorTransformer;
+use League\Fractal\Test\Stub\Transformer\JsonApiFaultyIncludeTransformer;
 
 class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 {
@@ -1738,6 +1739,38 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
         $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":5,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=5","first":"http:\/\/example.com\/books\/?page=1","prev":"http:\/\/example.com\/books\/?page=4","last":"http:\/\/example.com\/books\/?page=5"}}';
         $this->assertSame($expectedJson, $scope->toJson());
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testSerializingCollectionResourceWithEmptyHasOneIncludeWithFaultyTransformer()
+    {
+        $this->manager->parseIncludes('author');
+
+        $booksData = [
+          [
+            'id' => 1,
+            'title' => 'Foo',
+            'year' => '1991',
+            '_author' => [
+              'id' => 2,
+              'name' => 'Bob',
+            ],
+          ],
+          [
+            'id' => 2,
+            'title' => 'Bar',
+            'year' => '1997',
+            '_author' => null
+          ],
+        ];
+
+        $resource = new Collection($booksData, new JsonApiFaultyIncludeTransformer(), 'books');
+        $scope = new Scope($this->manager, $resource);
+
+        $scope->toArray();
+        $scope->toJson();
     }
 
     public function tearDown()

--- a/test/Stub/Transformer/JsonApiFaultyIncludeTransformer.php
+++ b/test/Stub/Transformer/JsonApiFaultyIncludeTransformer.php
@@ -1,0 +1,48 @@
+<?php namespace League\Fractal\Test\Stub\Transformer;
+
+use League\Fractal\TransformerAbstract;
+
+class JsonApiFaultyIncludeTransformer extends TransformerAbstract
+{
+  protected $availableIncludes = [
+    'author',
+    'co-author',
+  ];
+
+  public function transform(array $book)
+  {
+    $book['year'] = (int) $book['year'];
+    unset($book['_author']);
+    unset($book['_co_author']);
+
+    return $book;
+  }
+
+  public function includeAuthor(array $book)
+  {
+    if (!array_key_exists('_author', $book)) {
+      return;
+    }
+
+    if ($book['_author'] === null) {
+      // This should return $this->null() to work properly,
+      // but is set to return nothing for testing the exception.
+      return;
+    }
+
+    return $this->item($book['_author'], new JsonApiAuthorTransformer(), 'people');
+  }
+
+  public function includeCoAuthor(array $book)
+  {
+    if (!array_key_exists('_co_author', $book)) {
+      return;
+    }
+
+    if ($book['_co_author'] === null) {
+      return $this->null();
+    }
+
+    return $this->item($book['_co_author'], new JsonApiAuthorTransformer(), 'people');
+  }
+}


### PR DESCRIPTION
When using the JsonApiSerializer with a transformer that has includes, things get messy if the include callback does not return `$this->null()`

The result of not returning `$this->null()` is that the size of the original data, and the size of the relationship data does not match, so:

``` php
if ($this->isCollection($data)) {
            foreach ($relationships as $key => $relationship) {
                foreach ($relationship as $index => $relationshipData) {
                    $data['data'][$index]['relationships'][$key] = $relationshipData;
                }
            }
        }
```

will match the wrong relation data to the original data. (https://github.com/thephpleague/fractal/blob/master/src/Serializer/JsonApiSerializer.php#L299)

This PR throws an exception if the size of the relationship data does not match the size of the original data.
This could break excisting applications, but it would mean these applications are currently returning faulty data at this moment which might be even more harmfull?

I could also make a case for documenting returning $this->null() for includes that have no data for the relationship.

An alternative to the exception could be to fill the relationship with null data somewhere else in the transformation if no value is provided.
