### PR TITLE
Variable availableIncludes is not used by the scope class

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -28,11 +28,6 @@ use League\Fractal\Serializer\SerializerAbstract;
 class Scope
 {
     /**
-     * @var array
-     */
-    protected $availableIncludes = [];
-
-    /**
      * @var string
      */
     protected $scopeIdentifier;
@@ -385,8 +380,6 @@ class Scope
      */
     protected function fireIncludedTransformers($transformer, $data)
     {
-        $this->availableIncludes = $transformer->getAvailableIncludes();
-
         return $transformer->processIncludedResources($this, $data) ?: [];
     }
 

--- a/test/ScopeTest.php
+++ b/test/ScopeTest.php
@@ -201,7 +201,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $manager->parseIncludes('book');
 
         $transformer = Mockery::mock('League\Fractal\TransformerAbstract')->makePartial();
-        $transformer->shouldReceive('getAvailableIncludes')->twice()->andReturn(['book']);
+        $transformer->shouldReceive('getAvailableIncludes')->once()->andReturn(['book']);
         $transformer->shouldReceive('transform')->once()->andReturnUsing(function (array $data) {
             return $data;
         });
@@ -230,7 +230,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $manager->setSerializer($serializer);
 
         $transformer = Mockery::mock('League\Fractal\TransformerAbstract')->makePartial();
-        $transformer->shouldReceive('getAvailableIncludes')->twice()->andReturn(['book']);
+        $transformer->shouldReceive('getAvailableIncludes')->once()->andReturn(['book']);
         $transformer->shouldReceive('transform')->once()->andReturnUsing(function (array $data) {
             return $data;
         });


### PR DESCRIPTION
I also had to modify the unit tests in order for this to pass, since now there's no second call to `getAvailableIncludes` method
