### PR TITLE
Implement sparse fieldset

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -39,6 +39,13 @@ class Manager
     protected $requestedExcludes = [];
 
     /**
+     * Array of requested fieldsets.
+     *
+     * @var array
+     */
+    protected $requestedFieldsets = [];
+
+    /**
      * Array containing modifiers as keys and an array value of params.
      *
      * @var array
@@ -210,6 +217,47 @@ class Manager
         $this->autoIncludeParents();
 
         return $this;
+    }
+
+    /**
+     * Parse field parameter.
+     *
+     * @param array $fieldsets Array of fields to include. It must be an array
+     *                         whose keys are resource types and values a string
+     *                         of the fields to return, separated by a comma
+     *
+     * @return $this
+     */
+    public function parseFieldsets(array $fieldsets)
+    {
+        foreach ($fieldsets as $type => $fields) {
+            $this->requestedFieldsets[$type] = explode(',', $fields);
+        }
+        return $this;
+    }
+
+    /**
+     * Get requested fieldsets.
+     *
+     * @return array
+     */
+    public function getRequestedFieldsets()
+    {
+        return $this->requestedFieldsets;
+    }
+
+    /**
+     * Get fieldset params for the specified type.
+     *
+     * @param string $type
+     *
+     * @return \League\Fractal\ParamBag|null
+     */
+    public function getFieldset($type)
+    {
+        return !isset($this->requestedFieldsets[$type]) ?
+            null :
+            new ParamBag($this->requestedFieldsets[$type]);
     }
 
     /**

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -230,8 +230,10 @@ class Manager
      */
     public function parseFieldsets(array $fieldsets)
     {
+        $this->requestedFieldsets = [];
         foreach ($fieldsets as $type => $fields) {
-            $this->requestedFieldsets[$type] = explode(',', $fields);
+            //Remove empty and repeated fields
+            $this->requestedFieldsets[$type] = array_unique(array_filter(explode(',', $fields)));
         }
         return $this;
     }

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -242,6 +242,9 @@ class Scope
         if ($serializer->sideloadIncludes()) {
             $includedData = $serializer->includedData($this->resource, $rawIncludedData);
 
+            //Filter out any relation that wasn't requested
+            $rawIncludedData = array_map(array($this, 'filterFieldsets'), $rawIncludedData);
+
             // If the serializer wants to inject additional information
             // about the included resources, it can do so now.
             $data = $serializer->injectData($data, $rawIncludedData);
@@ -370,6 +373,9 @@ class Scope
             $transformedData = $this->manager->getSerializer()->mergeIncludes($transformedData, $includedData);
         }
 
+        //Stick only with requested fields
+        $transformedData = $this->filterFieldsets($transformedData);
+
         return [$transformedData, $includedData];
     }
 
@@ -419,5 +425,68 @@ class Scope
     protected function isRootScope()
     {
         return empty($this->parentScopes);
+    }
+
+    /**
+     * Filter the provided data with the requested filter fieldset for
+     * the scope resource
+     *
+     * @internal
+     *
+     * @param array  $data
+     *
+     * @return array
+     */
+    protected function filterFieldsets(array $data)
+    {
+        if (!$this->hasFilterFieldset()) {
+            return $data;
+        }
+        $serializer = $this->manager->getSerializer();
+        $requestedFieldset = iterator_to_array($this->getFilterFieldset());
+        //Build the array of requested fieldsets with the mandatory serializer fields
+        $filterFieldset = array_flip(
+            array_merge(
+                $serializer->getMandatoryFields(),
+                $requestedFieldset
+            )
+        );
+        return array_intersect_key($data, $filterFieldset);
+    }
+
+    /**
+     * Return the requested filter fieldset for the scope resource
+     *
+     * @internal
+     *
+     * @return \League\Fractal\ParamBag|null
+     */
+    protected function getFilterFieldset()
+    {
+        return $this->manager->getFieldset($this->getResourceType());
+    }
+
+    /**
+     * Check if there are requested filter fieldsets for the scope resource.
+     *
+     * @internal
+     *
+     * @return bool
+     */
+    protected function hasFilterFieldset()
+    {
+        return $this->getFilterFieldset() !== null;
+    }
+
+    /**
+     * Return the scope resource type.
+     *
+     * @internal
+     *
+     * @return string
+     */
+    protected function getResourceType()
+    {
+        return $this->resource->getResourceKey();
     }
 }

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -240,10 +240,10 @@ class Scope
         // If the serializer wants the includes to be side-loaded then we'll
         // serialize the included data and merge it with the data.
         if ($serializer->sideloadIncludes()) {
-            $includedData = $serializer->includedData($this->resource, $rawIncludedData);
-
             //Filter out any relation that wasn't requested
             $rawIncludedData = array_map(array($this, 'filterFieldsets'), $rawIncludedData);
+
+            $includedData = $serializer->includedData($this->resource, $rawIncludedData);
 
             // If the serializer wants to inject additional information
             // about the included resources, it can do so now.

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -245,6 +245,16 @@ class JsonApiSerializer extends ArraySerializer
     }
 
     /**
+     * Get the mandatory fields for the serializer
+     *
+     * @return array
+     */
+    public function getMandatoryFields()
+    {
+        return ['id'];
+    }
+
+    /**
      * Filter function to delete root objects from array.
      *
      * @param array $object

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -127,4 +127,14 @@ abstract class SerializerAbstract
     {
         return $includedData;
     }
+
+    /**
+     * Get the mandatory fields for the serializer
+     *
+     * @return array
+     */
+    public function getMandatoryFields()
+    {
+        return [];
+    }
 }

--- a/test/ManagerTest.php
+++ b/test/ManagerTest.php
@@ -1,6 +1,7 @@
 <?php namespace League\Fractal\Test;
 
 use League\Fractal\Manager;
+use League\Fractal\ParamBag;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
 use Mockery;
@@ -74,7 +75,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($params['totallymadeup']);
     }
 
-        public function testParseExcludeSelfie()
+    public function testParseExcludeSelfie()
     {
         $manager = new Manager();
 
@@ -193,6 +194,37 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(['data' => [['foo' => 'bar']]], $rootScope->toArray());
         $this->assertSame('{"data":[{"foo":"bar"}]}', $rootScope->toJson());
 
+    }
+
+    public function testParseFieldsets()
+    {
+        $manager = new Manager();
+
+        $fields = [
+            'articles' => 'title,body',
+            'people' => 'name'
+        ];
+
+        $expectedFieldset = [
+            'articles' => ['title' , 'body'],
+            'people' => ['name']
+        ];
+
+        $manager->parseFieldsets($fields);
+        $this->assertSame($expectedFieldset, $manager->getRequestedFieldsets());
+
+        $paramBag = new ParamBag($expectedFieldset['articles']);
+        $this->assertEquals($paramBag, $manager->getFieldset('articles'));
+
+        // Are repeated fields stripped
+        $manager->parseFieldsets(['foo' => 'bar,baz,bar']);
+        $this->assertSame(['foo' => ['bar', 'baz']], $manager->getRequestedFieldsets());
+
+        // Are empty fields stripped
+        $manager->parseFieldsets(['foo' => 'bar,']);
+        $this->assertSame(['foo' => ['bar']], $manager->getRequestedFieldsets());
+
+        $this->assertSame(null, $manager->getFieldset('inexistent'));
     }
 
     public function tearDown()

--- a/test/Serializer/ArraySerializerTest.php
+++ b/test/Serializer/ArraySerializerTest.php
@@ -56,7 +56,32 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $scope->toArray());
 
-        // Same again with meta
+        //Test single field
+        $manager->parseFieldsets(['book' => 'title']);
+        $expected = ['title' => 'Foo'];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test multiple field
+        $manager->parseFieldsets(['book' => 'title,year']);
+        $expected = [
+            'title' => 'Foo',
+            'year' => 1991
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test with relationship field
+        $manager->parseFieldsets(['book' => 'title,author', 'author' => 'name']);
+        $expected = [
+            'title' => 'Foo',
+            'author' => [
+                'name' => 'Dave'
+            ],
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Clear all sparse fieldsets
+        $manager->parseFieldsets([]);
+        //Same again with meta
         $resource->setMetaValue('foo', 'bar');
 
         $scope = new Scope($manager, $resource);
@@ -65,13 +90,26 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
             'title' => 'Foo',
             'year' => 1991,
             'author' => [
+                'name' => 'Dave'
+            ],
+            'meta' => [
+                'foo' => 'bar'
+            ]
+        ];
+
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test with relationship field
+        $manager->parseFieldsets(['book' => 'title,author', 'author' => 'name']);
+        $expected = [
+            'title' => 'Foo',
+            'author' => [
                 'name' => 'Dave',
             ],
             'meta' => [
                 'foo' => 'bar',
-            ],
+            ]
         ];
-
         $this->assertSame($expected, $scope->toArray());
     }
 
@@ -111,6 +149,55 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
         $expectedJson = '{"books":[{"title":"Foo","year":1991,"author":{"name":"Dave"}},{"title":"Bar","year":1997,"author":{"name":"Bob"}}]}';
         $this->assertSame($expectedJson, $scope->toJson());
 
+        //Test single field
+        $manager->parseFieldsets(['books' => 'title']);
+        $expected = [
+            'books' => [
+                ['title' => 'Foo'],
+                ['title' => 'Bar']
+            ]
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test multiple field
+        $manager->parseFieldsets(['books' => 'title,year']);
+        $expected = [
+            'books' => [
+                [
+                    'title' => 'Foo',
+                    'year' => 1991
+                ],
+                [
+                    'title' => 'Bar',
+                    'year' => 1997
+                ]
+            ]
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test with relationship field
+        $manager->parseFieldsets(['books' => 'title,author', 'author' => 'name']);
+        $expected = [
+            'books' => [
+                [
+                    'title' => 'Foo',
+                    'author' => [
+                        'name' => 'Dave'
+                    ]
+                ],
+                [
+                    'title' => 'Bar',
+                    'author' => [
+                        'name' => 'Bob'
+                    ]
+                ]
+            ]
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Clear all sparse fieldsets
+        $manager->parseFieldsets([]);
+
         // Same again with metadata
         $resource->setMetaValue('foo', 'bar');
 
@@ -142,6 +229,28 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
 
         $expectedJson = '{"books":[{"title":"Foo","year":1991,"author":{"name":"Dave"}},{"title":"Bar","year":1997,"author":{"name":"Bob"}}],"meta":{"foo":"bar"}}';
         $this->assertSame($expectedJson, $scope->toJson());
+
+        $manager->parseFieldsets(['books' => 'title,author', 'author' => 'name']);
+        $expected = [
+            'books' => [
+                [
+                    'title' => 'Foo',
+                    'author' => [
+                        'name' => 'Dave'
+                    ]
+                ],
+                [
+                    'title' => 'Bar',
+                    'author' => [
+                        'name' => 'Bob'
+                    ]
+                ]
+            ],
+            'meta' => [
+                'foo' => 'bar',
+            ]
+        ];
+        $this->assertSame($expected, $scope->toArray());
     }
 
     public function testSerializingNullResource()
@@ -162,6 +271,21 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
         $expectedJson = '[]';
         $this->assertSame($expectedJson, $scope->toJson());
 
+        //Test single field
+        $manager->parseFieldsets(['books' => 'title']);
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test multiple fields
+        $manager->parseFieldsets(['books' => 'title,year']);
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test with relationship
+        $manager->parseFieldsets(['books' => 'title,author', 'author' => 'name']);
+        $this->assertSame($expected, $scope->toArray());
+
+        //Clear all sparse fieldsets
+        $manager->parseFieldsets([]);
+
         // Same again with metadata
         $resource->setMetaValue('foo', 'bar');
         $scope = new Scope($manager, $resource);
@@ -175,6 +299,10 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
 
         $expectedJson = '{"meta":{"foo":"bar"}}';
         $this->assertSame($expectedJson, $scope->toJson());
+
+        //Test with relationship
+        $manager->parseFieldsets(['books' => 'title,author', 'author' => 'name']);
+        $this->assertSame($expected, $scope->toArray());
     }
 
     public function testSerializingCollectionResourceWithoutName()

--- a/test/Serializer/DataArraySerializerTest.php
+++ b/test/Serializer/DataArraySerializerTest.php
@@ -42,12 +42,47 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $scope->toArray());
 
+        //Test single field
+        $manager->parseFieldsets(['book' => 'title']);
+        $expected = [
+            'data' => [
+                'title' => 'Foo',
+            ]
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test multiple field
+        $manager->parseFieldsets(['book' => 'title,year']);
+        $expected = [
+            'data' => [
+                'title' => 'Foo',
+                'year' => 1991
+            ]
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test with relationship field
+        $manager->parseFieldsets(['book' => 'title,author', 'author' => 'name']);
+        $expected = [
+            'data' => [
+                'title' => 'Foo',
+                'author' => [
+                    'data' => [
+                        'name' => 'Dave'
+                    ]
+                ]
+            ]
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Clear all sparse fieldsets
+        $manager->parseFieldsets([]);
+
         // Same again with metadata
         $resource = new Item($bookData, new GenericBookTransformer(), 'book');
         $resource->setMetaValue('foo', 'bar');
 
         $scope = new Scope($manager, $resource);
-
 
         $expected = [
             'data' => [
@@ -65,6 +100,24 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test with relationship field
+        $manager->parseFieldsets(['book' => 'title,author', 'author' => 'name']);
+        $expected = [
+            'data' => [
+                'title' => 'Foo',
+                'author' => [
+                    'data' => [
+                        'name' => 'Dave'
+
+                    ]
+                ]
+            ],
+            'meta' => [
+                'foo' => 'bar'
+            ],
+        ];
         $this->assertSame($expected, $scope->toArray());
     }
 
@@ -92,7 +145,7 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
         ];
 
         // Try without metadata
-        $resource = new Collection($booksData, new GenericBookTransformer(), 'book');
+        $resource = new Collection($booksData, new GenericBookTransformer(), 'books');
 
         $scope = new Scope($manager, $resource);
 
@@ -124,8 +177,61 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
         $expectedJson = '{"data":[{"title":"Foo","year":1991,"author":{"data":{"name":"Dave"}}},{"title":"Bar","year":1997,"author":{"data":{"name":"Bob"}}}]}';
         $this->assertSame($expectedJson, $scope->toJson());
 
+        //Test single field
+        $manager->parseFieldsets(['books' => 'title']);
+        $expected = [
+            'data' => [
+                ['title' => 'Foo'],
+                ['title' => 'Bar']
+            ],
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test multiple field
+        $manager->parseFieldsets(['books' => 'title,year']);
+        $expected = [
+            'data' => [
+                [
+                    'title' => 'Foo',
+                    'year' => 1991
+                ],
+                [
+                    'title' => 'Bar',
+                    'year' => 1997
+                ]
+            ],
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test with relationship field
+        $manager->parseFieldsets(['books' => 'title,author', 'author' => 'name']);
+        $expected = [
+            'data' => [
+                [
+                    'title' => 'Foo',
+                    'author' => [
+                        'data' => [
+                            'name' => 'Dave'
+                        ]
+                    ]
+                ],
+                [
+                    'title' => 'Bar',
+                    'author' => [
+                        'data' => [
+                            'name' => 'Bob'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Clear all sparse fieldsets
+        $manager->parseFieldsets([]);
+
         // Same again with meta
-        $resource = new Collection($booksData, new GenericBookTransformer(), 'book');
+        $resource = new Collection($booksData, new GenericBookTransformer(), 'books');
         $resource->setMetaValue('foo', 'bar');
 
         $scope = new Scope($manager, $resource);
@@ -148,7 +254,6 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
                     'author' => [
                         'data' => [
                             'name' => 'Bob',
-
                         ],
                     ],
                 ],
@@ -162,6 +267,33 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
 
         $expectedJson = '{"data":[{"title":"Foo","year":1991,"author":{"data":{"name":"Dave"}}},{"title":"Bar","year":1997,"author":{"data":{"name":"Bob"}}}],"meta":{"foo":"bar"}}';
         $this->assertSame($expectedJson, $scope->toJson());
+
+        $manager->parseFieldsets(['books' => 'title,author', 'author' => 'name']);
+        $expected = [
+            'data' => [
+                [
+                    'title' => 'Foo',
+                    'author' => [
+                        'data' => [
+                            'name' => 'Dave'
+                        ]
+                    ]
+                ],
+                [
+                    'title' => 'Bar',
+                    'author' => [
+                        'data' => [
+                            'name' => 'Bob'
+                        ]
+                    ]
+                ]
+            ],
+            'meta' => [
+                'foo' => 'bar'
+            ]
+        ];
+
+        $this->assertSame($expected, $scope->toArray());
     }
 
     public function testSerializingNullResource()
@@ -187,6 +319,21 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
         ];
         $this->assertSame($expected, $scope->toArray());
 
+        //Test single field
+        $manager->parseFieldsets(['book' => 'title']);
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test multiple fields
+        $manager->parseFieldsets(['book' => 'title,year']);
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test with relationship
+        $manager->parseFieldsets(['book' => 'title,author', 'author' => 'name']);
+        $this->assertSame($expected, $scope->toArray());
+
+        //Clear all sparse fieldsets
+        $manager->parseFieldsets([]);
+
         // Same again with metadata
         $resource = new NullResource($bookData, new GenericBookTransformer(), 'book');
         $resource->setMetaValue('foo', 'bar');
@@ -199,6 +346,10 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
                 'foo' => 'bar',
             ],
         ];
+        $this->assertSame($expected, $scope->toArray());
+
+        //Test with relationship
+        $manager->parseFieldsets(['book' => 'title,author', 'author' => 'name']);
         $this->assertSame($expected, $scope->toArray());
     }
 

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -1740,6 +1740,157 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
+    /**
+     * @dataProvider serializingWithFieldsetsProvider
+     */
+    public function testSerializingWithFieldsets($fieldsetsToParse, $expected)
+    {
+        $this->manager->parseIncludes(['author', 'author.published']);
+
+        $bookData = [
+            'id' => 1,
+            'title' => 'Foo',
+            'year' => '1991',
+            '_author' => [
+                'id' => 1,
+                'name' => 'Dave',
+                '_published' => [
+                    [
+                        'id' => 1,
+                        'title' => 'Foo',
+                        'year' => '1991',
+                    ],
+                    [
+                        'id' => 2,
+                        'title' => 'Bar',
+                        'year' => '2015',
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+
+        $scope = new Scope($this->manager, $resource);
+
+        $this->manager->parseFieldsets($fieldsetsToParse);
+        $this->assertSame($expected, $scope->toArray());
+    }
+
+    public function serializingWithFieldsetsProvider()
+    {
+        return [
+            [
+                //Single field
+                ['books' => 'title'],
+                [
+                    'data' => [
+                        'type' => 'books',
+                        'id' => '1',
+                        'attributes' => [
+                            'title' => 'Foo'
+                        ]
+                    ]
+                ]
+            ],
+            [
+                //Multiple fields
+                ['books' => 'title,year'],
+                [
+                    'data' => [
+                        'type' => 'books',
+                        'id' => '1',
+                        'attributes' => [
+                            'title' => 'Foo',
+                            'year' => 1991
+                        ]
+                    ]
+                ]
+            ],
+            [
+                //Include 1st level relationship
+                ['books' => 'title,author', 'people' => 'name'],
+                [
+                    'data' => [
+                        'type' => 'books',
+                        'id' => '1',
+                        'attributes' => [
+                            'title' => 'Foo'
+                        ],
+                        'relationships' => [
+                            'author' => [
+                                'data' => [
+                                    'type' => 'people',
+                                    'id' => '1'
+                                ]
+                            ]
+                        ]
+                    ],
+                    'included' => [
+                        [
+                            'type' => 'people',
+                            'id' => '1',
+                            'attributes' => [
+                                'name' => 'Dave'
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                //Include 2nd level relationship
+                ['books' => 'title,author', 'people' => 'name,published'],
+                [
+                    'data' => [
+                        'type' => 'books',
+                        'id' => '1',
+                        'attributes' => [
+                            'title' => 'Foo'
+                        ],
+                        'relationships' => [
+                            'author' => [
+                                'data' => [
+                                    'type' => 'people',
+                                    'id' => '1'
+                                ]
+                            ]
+                        ]
+                    ],
+                    'included' => [
+                        [
+                            'type' => 'books',
+                            'id' => '2',
+                            'attributes' => [
+                                'title' => 'Bar'
+                            ]
+                        ],
+                        [
+                            'type' => 'people',
+                            'id' => '1',
+                            'attributes' => [
+                                'name' => 'Dave'
+                            ],
+                            'relationships' => [
+                                'published' => [
+                                    'data' => [
+                                        [
+                                            'type' => 'books',
+                                            'id' => '1'
+                                        ],
+                                        [
+                                            'type' => 'books',
+                                            'id' => '2'
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+
     public function tearDown()
     {
         Mockery::close();


### PR DESCRIPTION
Hi.

This is a first proposal to implement the [sparse fieldset feature](http://jsonapi.org/format/#fetching-sparse-fieldsets). The idea is to discuss the current implementation to improve on what was done :-)

This are the "major features" in order to respect JSON API spec:
- If no `field` param is specified current behavior is kept
- If one or more `fieldsets` are provided then, only the fields on those fieldsets are returned (only exception to this is the `id` field, that will _NEVER_ be removed)
- If one or more `fieldsets` are provided, relationship names _MUST_ also be provided, otherwise the `relationship` object [will not hold those relations](http://jsonapi.org/examples/#sparse-fieldsets)

To mimic the behavior of `includes`, we need to call a method `parseFieldsets()` in order filter the response fields.

The `fieldset` filter is respecting the JSON API, but it's also affecting the other serializers (just like the `included` relations work right now)

Don't accept the commit, because it's still missing unit test
