### PR TITLE
Feature/json api collection relationship links

### DIFF
--- a/src/Resource/ResourceInterface.php
+++ b/src/Resource/ResourceInterface.php
@@ -14,6 +14,13 @@ namespace League\Fractal\Resource;
 interface ResourceInterface
 {
     /**
+     * Get the resource key.
+     *
+     * @return string
+     */
+    public function getResourceKey();
+
+    /**
      * Get the data.
      *
      * @return mixed

--- a/src/Serializer/ArraySerializer.php
+++ b/src/Serializer/ArraySerializer.php
@@ -44,6 +44,16 @@ class ArraySerializer extends SerializerAbstract
     }
 
     /**
+     * Serialize null resource.
+     *
+     * @return array
+     */
+    public function null()
+    {
+        return [];
+    }
+
+    /**
      * Serialize the included data.
      *
      * @param ResourceInterface $resource

--- a/src/Serializer/DataArraySerializer.php
+++ b/src/Serializer/DataArraySerializer.php
@@ -38,4 +38,14 @@ class DataArraySerializer extends ArraySerializer
     {
         return ['data' => $data];
     }
+
+    /**
+     * Serialize null resource.
+     *
+     * @return array
+     */
+    public function null()
+    {
+        return ['data' => []];
+    }
 }

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -166,8 +166,7 @@ class JsonApiSerializer extends ArraySerializer
                 }
                 if ($this->isCollection($includeObject)) {
                     $includeObjects = $includeObject['data'];
-                }
-                else {
+                } else {
                     $includeObjects = [$includeObject['data']];
                 }
 
@@ -234,8 +233,7 @@ class JsonApiSerializer extends ArraySerializer
 
         if ($this->isCollection($data)) {
             $this->setRootObjects($data['data']);
-        }
-        else {
+        } else {
             $this->setRootObjects([$data['data']]);
         }
 
@@ -311,7 +309,8 @@ class JsonApiSerializer extends ArraySerializer
      *
      * @return bool
      */
-    protected function isEmpty($data) {
+    protected function isEmpty($data)
+    {
         return array_key_exists('data', $data) && $data['data'] === [];
     }
 
@@ -327,10 +326,18 @@ class JsonApiSerializer extends ArraySerializer
             foreach ($relationships as $key => $relationship) {
                 foreach ($relationship as $index => $relationshipData) {
                     $data['data'][$index]['relationships'][$key] = $relationshipData;
+
+                    if ($this->shouldIncludeLinks()) {
+                        $data['data'][$index]['relationships'][$key] = array_merge([
+                            'links' => [
+                                'self' => "{$this->baseUrl}/{$data['data'][$index]['type']}/{$data['data'][$index]['id']}/relationships/$key",
+                                'related' => "{$this->baseUrl}/{$data['data'][$index]['type']}/{$data['data'][$index]['id']}/$key",
+                            ],
+                        ], $data['data'][$index]['relationships'][$key]);
+                    }
                 }
             }
-        }
-        else { // Single resource
+        } else { // Single resource
             foreach ($relationships as $key => $relationship) {
                 $data['data']['relationships'][$key] = $relationship[0];
 
@@ -358,21 +365,18 @@ class JsonApiSerializer extends ArraySerializer
         $relationships = [];
 
         foreach ($includedData as $key => $inclusion) {
-            foreach ($inclusion as $includeKey => $includeObject)
-            {
+            foreach ($inclusion as $includeKey => $includeObject) {
                 if (!array_key_exists($includeKey, $relationships)) {
                     $relationships[$includeKey] = [];
                 }
 
                 if ($this->isNull($includeObject)) {
                     $relationship = $this->null();
-                }
-                elseif ($this->isEmpty($includeObject)) {
+                } elseif ($this->isEmpty($includeObject)) {
                     $relationship = [
                         'data' => [],
                     ];
-                }
-                elseif ($this->isCollection($includeObject)) {
+                } elseif ($this->isCollection($includeObject)) {
                     $relationship = ['data' => []];
 
                     foreach ($includeObject['data'] as $object) {
@@ -381,8 +385,7 @@ class JsonApiSerializer extends ArraySerializer
                             'id' => $object['id'],
                         ];
                     }
-                }
-                else {
+                } else {
                     $relationship = [
                         'data' => [
                             'type' => $includeObject['data']['type'],

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -20,6 +20,11 @@ class JsonApiSerializer extends ArraySerializer
     protected $baseUrl;
     protected $rootObjects;
 
+    /**
+     * JsonApiSerializer constructor.
+     *
+     * @param string $baseUrl
+     */
     public function __construct($baseUrl = null)
     {
         $this->baseUrl = $baseUrl;
@@ -30,7 +35,7 @@ class JsonApiSerializer extends ArraySerializer
      * Serialize a collection.
      *
      * @param string $resourceKey
-     * @param array  $data
+     * @param array $data
      *
      * @return array
      */
@@ -49,7 +54,7 @@ class JsonApiSerializer extends ArraySerializer
      * Serialize an item.
      *
      * @param string $resourceKey
-     * @param array  $data
+     * @param array $data
      *
      * @return array
      */
@@ -85,13 +90,13 @@ class JsonApiSerializer extends ArraySerializer
      */
     public function paginator(PaginatorInterface $paginator)
     {
-        $currentPage = (int) $paginator->getCurrentPage();
-        $lastPage = (int) $paginator->getLastPage();
+        $currentPage = (int)$paginator->getCurrentPage();
+        $lastPage = (int)$paginator->getLastPage();
 
         $pagination = [
-            'total' => (int) $paginator->getTotal(),
-            'count' => (int) $paginator->getCount(),
-            'per_page' => (int) $paginator->getPerPage(),
+            'total' => (int)$paginator->getTotal(),
+            'count' => (int)$paginator->getCount(),
+            'per_page' => (int)$paginator->getPerPage(),
             'current_page' => $currentPage,
             'total_pages' => $lastPage,
         ];
@@ -151,7 +156,7 @@ class JsonApiSerializer extends ArraySerializer
      * Serialize the included data.
      *
      * @param ResourceInterface $resource
-     * @param array             $data
+     * @param array $data
      *
      * @return array
      */
@@ -164,11 +169,8 @@ class JsonApiSerializer extends ArraySerializer
                 if ($this->isNull($includeObject) || $this->isEmpty($includeObject)) {
                     continue;
                 }
-                if ($this->isCollection($includeObject)) {
-                    $includeObjects = $includeObject['data'];
-                } else {
-                    $includeObjects = [$includeObject['data']];
-                }
+
+                $includeObjects = $this->createIncludeObjects($includeObject);
 
                 foreach ($includeObjects as $object) {
                     $includeType = $object['type'];
@@ -214,14 +216,13 @@ class JsonApiSerializer extends ArraySerializer
 
     /**
      * Hook to manipulate the final sideloaded includes.
-     *
      * The JSON API specification does not allow the root object to be included
      * into the sideloaded `included`-array. We have to make sure it is
      * filtered out, in case some object links to the root object in a
      * relationship.
      *
-     * @param array             $includedData
-     * @param array             $data
+     * @param array $includedData
+     * @param array $data
      *
      * @return array
      */
@@ -231,11 +232,8 @@ class JsonApiSerializer extends ArraySerializer
             return $includedData;
         }
 
-        if ($this->isCollection($data)) {
-            $this->setRootObjects($data['data']);
-        } else {
-            $this->setRootObjects([$data['data']]);
-        }
+        // Create the RootObjects
+        $this->createRootObjects($data);
 
         // Filter out the root objects
         $filteredIncludes = array_filter($includedData['included'], [$this, 'filterRootObject']);
@@ -291,7 +289,7 @@ class JsonApiSerializer extends ArraySerializer
     protected function isCollection($data)
     {
         return array_key_exists('data', $data) &&
-               array_key_exists(0, $data['data']);
+        array_key_exists(0, $data['data']);
     }
 
     /**
@@ -318,37 +316,17 @@ class JsonApiSerializer extends ArraySerializer
      * @param array $data
      * @param array $relationships
      *
-     * @return mixed
+     * @return array
      */
     protected function fillRelationships($data, $relationships)
     {
         if ($this->isCollection($data)) {
             foreach ($relationships as $key => $relationship) {
-                foreach ($relationship as $index => $relationshipData) {
-                    $data['data'][$index]['relationships'][$key] = $relationshipData;
-
-                    if ($this->shouldIncludeLinks()) {
-                        $data['data'][$index]['relationships'][$key] = array_merge([
-                            'links' => [
-                                'self' => "{$this->baseUrl}/{$data['data'][$index]['type']}/{$data['data'][$index]['id']}/relationships/$key",
-                                'related' => "{$this->baseUrl}/{$data['data'][$index]['type']}/{$data['data'][$index]['id']}/$key",
-                            ],
-                        ], $data['data'][$index]['relationships'][$key]);
-                    }
-                }
+                $data = $this->fillRelationshipAsCollection($data, $relationship, $key);
             }
         } else { // Single resource
             foreach ($relationships as $key => $relationship) {
-                $data['data']['relationships'][$key] = $relationship[0];
-
-                if ($this->shouldIncludeLinks()) {
-                    $data['data']['relationships'][$key] = array_merge([
-                        'links' => [
-                            'self' => "{$this->baseUrl}/{$data['data']['type']}/{$data['data']['id']}/relationships/$key",
-                            'related' => "{$this->baseUrl}/{$data['data']['type']}/{$data['data']['id']}/$key",
-                        ],
-                    ], $data['data']['relationships'][$key]);
-                }
+                $data = $this->fillRelationshipAsSingleResource($data, $relationship, $key);
             }
         }
 
@@ -366,35 +344,7 @@ class JsonApiSerializer extends ArraySerializer
 
         foreach ($includedData as $key => $inclusion) {
             foreach ($inclusion as $includeKey => $includeObject) {
-                if (!array_key_exists($includeKey, $relationships)) {
-                    $relationships[$includeKey] = [];
-                }
-
-                if ($this->isNull($includeObject)) {
-                    $relationship = $this->null();
-                } elseif ($this->isEmpty($includeObject)) {
-                    $relationship = [
-                        'data' => [],
-                    ];
-                } elseif ($this->isCollection($includeObject)) {
-                    $relationship = ['data' => []];
-
-                    foreach ($includeObject['data'] as $object) {
-                        $relationship['data'][] = [
-                            'type' => $object['type'],
-                            'id' => $object['id'],
-                        ];
-                    }
-                } else {
-                    $relationship = [
-                        'data' => [
-                            'type' => $includeObject['data']['type'],
-                            'id' => $includeObject['data']['id'],
-                        ],
-                    ];
-                }
-
-                $relationships[$includeKey][$key] = $relationship;
+                $relationships = $this->buildRelationships($includeKey, $relationships, $includeObject, $key);
             }
         }
 
@@ -404,7 +354,7 @@ class JsonApiSerializer extends ArraySerializer
     /**
      * @param array $data
      *
-     * @return mixed
+     * @return integer
      */
     protected function getIdFromData(array $data)
     {
@@ -456,5 +406,160 @@ class JsonApiSerializer extends ArraySerializer
     protected function shouldIncludeLinks()
     {
         return $this->baseUrl !== null;
+    }
+
+    /**
+     * Check if the objects are part of a collection or not
+     *
+     * @param $includeObject
+     *
+     * @return array
+     */
+    private function createIncludeObjects($includeObject)
+    {
+        if ($this->isCollection($includeObject)) {
+            $includeObjects = $includeObject['data'];
+
+            return $includeObjects;
+        } else {
+            $includeObjects = [$includeObject['data']];
+
+            return $includeObjects;
+        }
+    }
+
+    /**
+     * Sets the RootObjects, either as collection or not.
+     *
+     * @param $data
+     */
+    private function createRootObjects($data)
+    {
+        if ($this->isCollection($data)) {
+            $this->setRootObjects($data['data']);
+        } else {
+            $this->setRootObjects([$data['data']]);
+        }
+    }
+
+
+    /**
+     * Loops over the relationships of the provided data and formats it
+     *
+     * @param $data
+     * @param $relationship
+     * @param $key
+     *
+     * @return array
+     */
+    private function fillRelationshipAsCollection($data, $relationship, $key)
+    {
+        foreach ($relationship as $index => $relationshipData) {
+            $data['data'][$index]['relationships'][$key] = $relationshipData;
+
+            if ($this->shouldIncludeLinks()) {
+                $data['data'][$index]['relationships'][$key] = array_merge([
+                    'links' => [
+                        'self' => "{$this->baseUrl}/{$data['data'][$index]['type']}/{$data['data'][$index]['id']}/relationships/$key",
+                        'related' => "{$this->baseUrl}/{$data['data'][$index]['type']}/{$data['data'][$index]['id']}/$key",
+                    ],
+                ], $data['data'][$index]['relationships'][$key]);
+            }
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * @param $data
+     * @param $relationship
+     * @param $key
+     *
+     * @return array
+     */
+    private function fillRelationshipAsSingleResource($data, $relationship, $key)
+    {
+        $data['data']['relationships'][$key] = $relationship[0];
+
+        if ($this->shouldIncludeLinks()) {
+            $data['data']['relationships'][$key] = array_merge([
+                'links' => [
+                    'self' => "{$this->baseUrl}/{$data['data']['type']}/{$data['data']['id']}/relationships/$key",
+                    'related' => "{$this->baseUrl}/{$data['data']['type']}/{$data['data']['id']}/$key",
+                ],
+            ], $data['data']['relationships'][$key]);
+        }
+        return $data;
+    }
+
+    /**
+     * @param $includeKey
+     * @param $relationships
+     * @param $includeObject
+     * @param $key
+     *
+     * @return array
+     */
+    private function buildRelationships($includeKey, $relationships, $includeObject, $key)
+    {
+        $relationships = $this->addIncludekeyToRelationsIfNotSet($includeKey, $relationships);
+
+        if ($this->isNull($includeObject)) {
+            $relationship = $this->null();
+        } elseif ($this->isEmpty($includeObject)) {
+            $relationship = [
+                'data' => [],
+            ];
+        } elseif ($this->isCollection($includeObject)) {
+            $relationship = ['data' => []];
+
+            $relationship = $this->addIncludedDataToRelationship($includeObject, $relationship);
+        } else {
+            $relationship = [
+                'data' => [
+                    'type' => $includeObject['data']['type'],
+                    'id' => $includeObject['data']['id'],
+                ],
+            ];
+        }
+
+        $relationships[$includeKey][$key] = $relationship;
+
+        return $relationships;
+    }
+
+    /**
+     * @param $includeKey
+     * @param $relationships
+     *
+     * @return array
+     */
+    private function addIncludekeyToRelationsIfNotSet($includeKey, $relationships)
+    {
+        if (!array_key_exists($includeKey, $relationships)) {
+            $relationships[$includeKey] = [];
+            return $relationships;
+        }
+
+        return $relationships;
+    }
+
+    /**
+     * @param $includeObject
+     * @param $relationship
+     *
+     * @return array
+     */
+    private function addIncludedDataToRelationship($includeObject, $relationship)
+    {
+        foreach ($includeObject['data'] as $object) {
+            $relationship['data'][] = [
+                'type' => $object['type'],
+                'id' => $object['id'],
+            ];
+        }
+
+        return $relationship;
     }
 }

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -38,6 +38,13 @@ abstract class SerializerAbstract
     abstract public function item($resourceKey, array $data);
 
     /**
+     * Serialize null resource.
+     *
+     * @return array
+     */
+    abstract public function null();
+
+    /**
      * Serialize the included data.
      *
      * @param ResourceInterface $resource

--- a/test/Serializer/ArraySerializerTest.php
+++ b/test/Serializer/ArraySerializerTest.php
@@ -3,6 +3,7 @@
 use League\Fractal\Manager;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
+use League\Fractal\Resource\NullResource;
 use League\Fractal\Scope;
 use League\Fractal\Serializer\ArraySerializer;
 use League\Fractal\Test\Stub\Transformer\GenericBookTransformer;
@@ -140,6 +141,39 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
         $this->assertSame($expected, $scope->toArray());
 
         $expectedJson = '{"books":[{"title":"Foo","year":1991,"author":{"name":"Dave"}},{"title":"Bar","year":1997,"author":{"name":"Bob"}}],"meta":{"foo":"bar"}}';
+        $this->assertSame($expectedJson, $scope->toJson());
+    }
+
+    public function testSerializingNullResource()
+    {
+        $manager = new Manager();
+        $manager->parseIncludes('author');
+        $manager->setSerializer(new ArraySerializer());
+
+        $resource = new NullResource($this->bookCollectionInput, new GenericBookTransformer(), 'books');
+
+        // Try without metadata
+        $scope = new Scope($manager, $resource);
+
+        $expected = [];
+        $this->assertSame($expected, $scope->toArray());
+
+        // JSON array of JSON objects
+        $expectedJson = '[]';
+        $this->assertSame($expectedJson, $scope->toJson());
+
+        // Same again with metadata
+        $resource->setMetaValue('foo', 'bar');
+        $scope = new Scope($manager, $resource);
+
+        $expected = [
+            'meta' => [
+                'foo' => 'bar',
+            ],
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        $expectedJson = '{"meta":{"foo":"bar"}}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 

--- a/test/Serializer/DataArraySerializerTest.php
+++ b/test/Serializer/DataArraySerializerTest.php
@@ -3,6 +3,7 @@
 use League\Fractal\Manager;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
+use League\Fractal\Resource\NullResource;
 use League\Fractal\Scope;
 use League\Fractal\Serializer\DataArraySerializer;
 use League\Fractal\Test\Stub\Transformer\GenericBookTransformer;
@@ -161,6 +162,44 @@ class DataArraySerializerTest extends PHPUnit_Framework_TestCase
 
         $expectedJson = '{"data":[{"title":"Foo","year":1991,"author":{"data":{"name":"Dave"}}},{"title":"Bar","year":1997,"author":{"data":{"name":"Bob"}}}],"meta":{"foo":"bar"}}';
         $this->assertSame($expectedJson, $scope->toJson());
+    }
+
+    public function testSerializingNullResource()
+    {
+        $manager = new Manager();
+        $manager->parseIncludes('author');
+        $manager->setSerializer(new DataArraySerializer());
+
+        $bookData = [
+            'title' => 'Foo',
+            'year' => '1991',
+            '_author' => [
+                'name' => 'Dave',
+            ],
+        ];
+
+        // Try without metadata
+        $resource = new NullResource($bookData, new GenericBookTransformer(), 'book');
+        $scope = new Scope($manager, $resource);
+
+        $expected = [
+            'data' => [],
+        ];
+        $this->assertSame($expected, $scope->toArray());
+
+        // Same again with metadata
+        $resource = new NullResource($bookData, new GenericBookTransformer(), 'book');
+        $resource->setMetaValue('foo', 'bar');
+
+        $scope = new Scope($manager, $resource);
+
+        $expected = [
+            'data' => [],
+            'meta' => [
+                'foo' => 'bar',
+            ],
+        ];
+        $this->assertSame($expected, $scope->toArray());
     }
 
     public function tearDown()


### PR DESCRIPTION
JSON-API Collections and Collection Paginations are not including the links on relationships while Item resources are. This will be ideal to add as it enables extended HATEOAS support.

Also, is this package keeping with PSR-2 standards or something else?