### PR TITLE
Always returns a ParamBag

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -98,15 +98,11 @@ class Manager
      *
      * @param string $include
      *
-     * @return \League\Fractal\ParamBag|null
+     * @return \League\Fractal\ParamBag
      */
     public function getIncludeParams($include)
     {
-        if (! isset($this->includeParams[$include])) {
-            return;
-        }
-
-        $params = $this->includeParams[$include];
+        $params = isset($this->includeParams[$include]) ? $this->includeParams[$include] : [];
 
         return new ParamBag($params);
     }

--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -14,7 +14,7 @@ namespace League\Fractal;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
 use League\Fractal\Resource\NullResource;
-use League\Fractal\Resource\ResourceAbstract;
+use League\Fractal\Resource\ResourceInterface;
 
 /**
  * Transformer Abstract
@@ -188,13 +188,13 @@ abstract class TransformerAbstract
             return false;
         }
 
-        if (! $resource instanceof ResourceAbstract) {
+        if (! $resource instanceof ResourceInterface) {
             throw new \Exception(sprintf(
                 'Invalid return value from %s::%s(). Expected %s, received %s.',
                 __CLASS__,
                 $methodName,
-                'League\Fractal\Resource\ResourceAbstract',
-                gettype($resource)
+                'League\Fractal\Resource\ResourceInterface',
+                is_object($resource) ? get_class($resource) : gettype($resource)
             ));
         }
 


### PR DESCRIPTION
Having to check whether there is a ParamBag or not is error prone.

This PR ensures Transformers are always called with a `ParamBag` instance.
