### PR TITLE
Fisrt draft for a possible implementation of HAL on fractal

### DIFF
--- a/src/Hal/Currie.php
+++ b/src/Hal/Currie.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace League\Fractal\Hal;
+
+use League\Fractal\Helper\Validator;
+
+class Currie
+{
+    const RELATION = '/{rel}';
+
+    private $name;
+
+    private $href;
+
+    private $templated = false;
+
+    private $resources;
+
+    public function __construct($name, $href, $templated, array $resources)
+    {
+        Validator::validateParamString('name', $name);
+        Validator::validateParamString('href', $href);
+        Validator::validateParamBool('templated', $templated);
+
+        $this->name = $name;
+        $this->href = $href;
+        $this->templated = $templated;
+        $this->resources = $resources;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHref()
+    {
+        return $this->href ? $this->href . static::RELATION : '';
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isTemplated()
+    {
+        return $this->templated;
+    }
+
+    /**
+     * @return CurrieResource[]
+     */
+    public function getResources()
+    {
+        return $this->resources;
+    }
+}

--- a/src/Hal/CurrieResource.php
+++ b/src/Hal/CurrieResource.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace League\Fractal\Hal;
+
+use League\Fractal\Helper\Validator;
+
+class CurrieResource
+{
+    private $key;
+
+    private $href;
+
+    public function __construct($key, $href)
+    {
+        Validator::validateParamString('key', $key);
+        Validator::validateParamString('href', $href);
+
+        $this->key = $key;
+        $this->href = $href;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHref()
+    {
+        return $this->href;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+}

--- a/src/Hal/CurrieResourceTransformer.php
+++ b/src/Hal/CurrieResourceTransformer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace League\Fractal\Hal;
+
+use League\Fractal\TransformerAbstract;
+
+class CurrieResourceTransformer extends TransformerAbstract
+{
+    protected $currieName;
+
+    public function __construct($currieName)
+    {
+        $this->currieName = $currieName . '.';
+    }
+
+    public function transform(CurrieResource $resource)
+    {
+        return [
+            $this->currieName . $resource->getKey() => $resource->getHref()
+        ];
+    }
+}

--- a/src/Hal/CurrieTransformer.php
+++ b/src/Hal/CurrieTransformer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace League\Fractal\Hal;
+
+use League\Fractal\TransformerAbstract;
+
+class CurrieTransformer extends TransformerAbstract
+{
+    /**
+     * List of resources to automatically include.
+     *
+     * @var array
+     */
+    protected $defaultIncludes = [
+        'resources'
+    ];
+
+    /**
+     * Transformation representation of currie OBJ.
+     *
+     * @param Currie $currie Currie OBJ.
+     *
+     * @return array Currie OBJ transformed.
+     */
+    public function transform(Currie $currie)
+    {
+        return [
+            'name' => $currie->getName(),
+            'href' => $currie->getHref()
+        ];
+    }
+
+    /**
+     * Include currie resources.
+     *
+     * @param Currie $currie Resource curries.
+     *
+     * @return \League\Fractal\Resource\Item Fractal resource item OBJ.
+     */
+    public function includeResources(Currie $currie)
+    {
+        return $this->collection($currie->getResources(), new CurrieResourceTransformer($currie->getName()));
+    }
+}

--- a/src/Hal/HalInterface.php
+++ b/src/Hal/HalInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace League\Fractal\Hal;
+
+interface HalInterface
+{
+    const STRUCTURE_KEY = '_links';
+
+    /**
+     * Get self link.
+     *
+     * @return string URL resource for self resource data.
+     */
+    public function getSelfLink();
+
+    /**
+     * Get next link.
+     *
+     * @return string URL link of next resources data (can be empty).
+     */
+    public function getNextLink();
+
+    /**
+     * Previous link.
+     *
+     * @return string URL link of previous resources data (can be empty).
+     */
+    public function getPreviousLink();
+
+    /**
+     * @return CurrieResource[]
+     */
+    public function getCurries();
+}

--- a/src/Hal/HalTransformer.php
+++ b/src/Hal/HalTransformer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace League\Fractal\Hal;
+
+use League\Fractal\TransformerAbstract;
+
+/**
+ * Class responsible for the Hypertext Application Language (HAL) transformation.
+ *
+ * @package League\Fractal\Hal
+ */
+class HalTransformer extends TransformerAbstract
+{
+    /**
+     * List of resources to automatically include.
+     *
+     * @var array
+     */
+    protected $defaultIncludes = [
+        'curries'
+    ];
+
+    /**
+     * Transform data to output.
+     *
+     * @param HalInterface $resource Links to the current data.
+     *
+     * @return array List with transformed data.
+     */
+    public function transform(HalInterface $resource)
+    {
+        return [
+            'self'     => $resource->getSelfLink(),
+            'next'     => $resource->getNextLink(),
+            'previous' => $resource->getPreviousLink()
+        ];
+    }
+
+    /**
+     * Include resources locations.
+     *
+     * @param HalInterface $resource Links to the current data.
+     *
+     * @return \League\Fractal\Resource\Item Fractal resource item OBJ.
+     */
+    public function includeCurries(HalInterface $resource)
+    {
+        return $this->collection($resource->getCurries(), new CurrieTransformer());
+    }
+}

--- a/src/Helper/Validator.php
+++ b/src/Helper/Validator.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace League\Fractal\Helper;
+
+use InvalidArgumentException;
+
+/**
+ * Validator for function params.
+ *
+ * @package League\Fractal\Helper
+ */
+final class Validator
+{
+    const NOT_VALID_PARAM_TYPE = 'Param received "%s" is not valid. Should be %s.';
+
+    /**
+     * Evaluates that a parameter received on a function is type string.
+     *
+     * @param string $name The name of the parameter that is being evaluated.
+     * @param mixed $value Value received on the function to be evaluated as string.
+     *
+     * @return void
+     * @throws Not valid param received on function.
+     */
+    public static function validateParamString($name, $value)
+    {
+        if (!is_string($value)) {
+            throw new InvalidArgumentException(sprintf(static::NOT_VALID_PARAM_TYPE, $name, 'string'));
+        }
+    }
+
+    /**
+     * Evaluates that a parameter received on a function is type boolean.
+     *
+     * @param string $name The name of the parameter that is being evaluated.
+     * @param mixed $value Value received on the function to be evaluated as boolean.
+     *
+     * @return void
+     * @throws Not valid param received on function.
+     */
+    public static function validateParamBool($name, $value)
+    {
+        if (!is_bool($value)) {
+            throw new InvalidArgumentException(sprintf(static::NOT_VALID_PARAM_TYPE, $name, 'boolean'));
+        }
+    }
+}

--- a/test/Hal/CurrieTest.php
+++ b/test/Hal/CurrieTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace League\Fractal\Test\Hal;
+
+use League\Fractal\Hal\Currie;
+
+class CurrieTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testNotValidStringParam()
+    {
+        new Currie(true, 'href', true, []);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testNotValidBoolParam()
+    {
+        new Currie('name', 'href', 'true', []);
+    }
+}

--- a/test/Hal/HalTest.php
+++ b/test/Hal/HalTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace League\Fractal\Test\Hal;
+
+use League\Fractal\Hal\HalInterface;
+use League\Fractal\TransformerAbstract;
+use League\Fractal\Manager;
+use League\Fractal\Resource\Item;
+use League\Fractal\Serializer\ArraySerializer;
+
+class HalTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHalOutputIsAdded()
+    {
+        $manager = new Manager();
+        $manager->setSerializer(new ArraySerializer());
+
+        $book = Book::getBook();
+        $resource = new Item($book, new BookTransformer());
+
+        $data = $manager->createData($resource)->toArray();
+        $this->assertArrayHasKey('_links', $data);
+
+        $data = $data['_links'];
+        $this->assertArrayHasKey('self', $data);
+        $this->assertArrayHasKey('next', $data);
+        $this->assertArrayHasKey('previous', $data);
+    }
+}
+
+class Book implements HalInterface
+{
+    public $id;
+    public $title;
+    public $yr;
+    public $author_name;
+    public $author_email;
+
+    public static function getBook(){
+        $book = new Book();
+        $book->id = 1;
+        $book->title = 'the title';
+        $book->yr = 'the yr';
+        $book->author_name = 'test';
+        $book->author_email = 'test@test.pt';
+
+        return $book;
+    }
+
+    public function getSelfLink()
+    {
+        return 'self.html' . $this->id;
+    }
+
+    public function getNextLink()
+    {
+        return 'next.html' . $this->id;
+    }
+
+    public function getPreviousLink()
+    {
+        return 'previous.html' . $this->id;
+    }
+
+    public function getCurries()
+    {
+        return [];
+    }
+}
+
+class BookTransformer extends TransformerAbstract
+{
+    public function transform(Book $book)
+    {
+        return [
+            'id'      => (int) $book->id,
+            'title'   => $book->title,
+            'year'    => $book->yr,
+            'author'  => [
+                'name'  => $book->author_name,
+                'email' => $book->author_email
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Could this be a possible solution for a HAL on fractal.

To implement this the class that needs HAL implementation should implement HalInterface 
ex:
class Book implements League\Fractal\Hal\HalInterface
{

With this fractal engine knows that it can generate the HAL structure.

This is not a final version just a first draft to be discussed as possible implementation, a serializer for HAL could be added but the data classes must implement the HalInterface.

With the current solution some fixes still need to be done like use always for HAL the ArraySerializer so data key is not added to end result.

Some tests where added but since its a first draft I only added 2.




