### PR TITLE
Allow includes to be an empty object.

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -273,6 +273,10 @@ class Scope
         // Pull out all of OUR metadata and any custom meta data to merge with the main level data
         $meta = $serializer->meta($this->resource->getMeta());
 
+        if (is_object($data)) {
+            return (object) array_merge((array) $data, $meta);
+        }
+
         return array_merge($data, $meta);
     }
 

--- a/test/ScopeTest.php
+++ b/test/ScopeTest.php
@@ -4,6 +4,7 @@ use League\Fractal\Manager;
 use League\Fractal\Pagination\Cursor;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
+use League\Fractal\Resource\NullResource;
 use League\Fractal\Scope;
 use League\Fractal\Serializer\ArraySerializer;
 use League\Fractal\Test\Stub\Transformer\DefaultIncludeBookTransformer;
@@ -246,6 +247,21 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->assertSame($expected, $scope->toArray());
+    }
+
+    public function testItCanReturnAnObject()
+    {
+        $serializer = Mockery::mock('League\Fractal\Serializer\ArraySerializer')->makePartial();
+        $serializer->shouldReceive('null')->andReturn((object) []);
+
+        $manager = new Manager();
+        $manager->setSerializer($serializer);
+
+        $resource = new NullResource;
+
+        $scope = new Scope($manager, $resource);
+
+        $this->assertEquals((object) [], $scope->toArray());
     }
 
     public function testPushParentScope()


### PR DESCRIPTION
Fixes #195 

In my projects I like to return Item includes as objects, not nested in a data array.

![screen shot 2016-04-13 at 2 15 16 pm](https://cloud.githubusercontent.com/assets/3682518/14504924/d9be1f8a-0184-11e6-895b-5c76454214f8.png)

This is easily accomplished with a serializer,  but I would like to be able to return null items in the same way.

![screen shot 2016-04-13 at 2 42 06 pm](https://cloud.githubusercontent.com/assets/3682518/14505174/01ec2924-0186-11e6-8ba9-ff7293e4c29e.png)

I would think the implementation would look something like this in a custom serializer:

![screen shot 2016-04-13 at 2 27 34 pm](https://cloud.githubusercontent.com/assets/3682518/14504911/cb40860a-0184-11e6-8c14-2c1f3d256c4e.png)

The problem is the toArray() in the Scope will not run because array_merge cannot take an object.  This fix simply checks if the data variable is an object and returns right before the array_merge call.
