### PR TITLE
Removed root key in included payload

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -301,10 +301,10 @@ class Scope
         $transformedData = $includedData = [];
 
         if ($this->resource instanceof Item) {
-            list($transformedData, $includedData[]) = $this->fireTransformer($transformer, $data);
+            list($transformedData, $includedData) = $this->fireTransformer($transformer, $data);
         } elseif ($this->resource instanceof Collection) {
             foreach ($data as $value) {
-                list($transformedData[], $includedData[]) = $this->fireTransformer($transformer, $value);
+                list($transformedData[], $includedData) = $this->fireTransformer($transformer, $value);
             }
         } elseif ($this->resource instanceof NullResource) {
             $transformedData = null;


### PR DESCRIPTION
When returning included data as sideload it returns the following:

```
{
"user": {"id": 1, "name": "test"}, 
"0":{"sideloadresource":[{"id": 1}],[]}
}
```

What it should return

```
{
"user": {"id": 1, "name": "test"}, 
"sideloadresource":[{"id": 1]}]
}
```

My fix removed the empty array as well removed the 0 key on root sideload.

Hope this fix does not cause other issues.
