### PR TITLE
Null resource serialization

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -335,12 +335,14 @@ class Scope
     {
         $resourceKey = $this->resource->getResourceKey();
 
-        if ($this->resource instanceof Collection) {
-            return $serializer->collection($resourceKey, $data);
-        }
+        if (null !== $data) {
+            if ($this->resource instanceof Collection) {
+                return $serializer->collection($resourceKey, $data);
+            }
 
-        if ($this->resource instanceof Item) {
-            return $serializer->item($resourceKey, $data);
+            if ($this->resource instanceof Item) {
+                return $serializer->item($resourceKey, $data);
+            }
         }
 
         return $serializer->null($resourceKey);

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -227,7 +227,9 @@ class Scope
     /**
      * Convert the current data for this scope to an array.
      *
-     * @return array
+     * In case Serializer used could return null, this could also return null
+     *
+     * @return array|null
      */
     public function toArray()
     {
@@ -273,7 +275,7 @@ class Scope
         // Pull out all of OUR metadata and any custom meta data to merge with the main level data
         $meta = $serializer->meta($this->resource->getMeta());
 
-        return array_merge($data, $meta);
+        return null === $data ? null : array_merge($data, $meta);
     }
 
     /**

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -341,7 +341,7 @@ class Scope
             return $serializer->item($resourceKey, $data);
         }
 
-        return $serializer->null();
+        return $serializer->null($resourceKey);
     }
 
     /**

--- a/src/Serializer/ArraySerializer.php
+++ b/src/Serializer/ArraySerializer.php
@@ -48,7 +48,7 @@ class ArraySerializer extends SerializerAbstract
      *
      * @param string $resourceKey
      *
-     * @return array
+     * @return array|null
      */
     public function null($resourceKey)
     {

--- a/src/Serializer/ArraySerializer.php
+++ b/src/Serializer/ArraySerializer.php
@@ -46,9 +46,11 @@ class ArraySerializer extends SerializerAbstract
     /**
      * Serialize null resource.
      *
+     * @param string $resourceKey
+     *
      * @return array
      */
-    public function null()
+    public function null($resourceKey)
     {
         return [];
     }

--- a/src/Serializer/DataArraySerializer.php
+++ b/src/Serializer/DataArraySerializer.php
@@ -42,9 +42,11 @@ class DataArraySerializer extends ArraySerializer
     /**
      * Serialize null resource.
      *
+     * @param string $resourceKey
+     *
      * @return array
      */
-    public function null()
+    public function null($resourceKey)
     {
         return ['data' => []];
     }

--- a/src/Serializer/ExplicitNullArraySerializer.php
+++ b/src/Serializer/ExplicitNullArraySerializer.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the League\Fractal package.
+ *
+ * (c) Phil Sturgeon <me@philsturgeon.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\Fractal\Serializer;
+
+class ExplicitNullArraySerializer extends ArraySerializer
+{
+    /**
+     * Serialize null resource.
+     *
+     * @param string $resourceKey
+     *
+     * @return array|null
+     */
+    public function null($resourceKey)
+    {
+        return null;
+    }
+}

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -143,9 +143,10 @@ class JsonApiSerializer extends ArraySerializer
     }
 
     /**
+     * @param string $resourceKey
      * @return array
      */
-    public function null()
+    public function null($resourceKey)
     {
         return [
             'data' => null,
@@ -499,7 +500,7 @@ class JsonApiSerializer extends ArraySerializer
         $relationships = $this->addIncludekeyToRelationsIfNotSet($includeKey, $relationships);
 
         if ($this->isNull($includeObject)) {
-            $relationship = $this->null();
+            $relationship = $this->null($includeKey);
         } elseif ($this->isEmpty($includeObject)) {
             $relationship = [
                 'data' => [],

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -199,7 +199,7 @@ class JsonApiSerializer extends ArraySerializer
     }
 
     /**
-     * @param array $data
+     * @param array|null $data
      * @param array $includedData
      *
      * @return array
@@ -209,10 +209,10 @@ class JsonApiSerializer extends ArraySerializer
         $relationships = $this->parseRelationships($includedData);
 
         if (!empty($relationships)) {
-            $data = $this->fillRelationships($data, $relationships);
+            $data = $this->fillRelationships((array)$data, $relationships);
         }
 
-        return $data;
+        return (array)$data;
     }
 
     /**

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -107,14 +107,14 @@ abstract class SerializerAbstract
     /**
      * Hook for the serializer to inject custom data based on the relationships of the resource.
      *
-     * @param array $data
+     * @param array|null $data
      * @param array $rawIncludedData
      *
      * @return array
      */
     public function injectData($data, $rawIncludedData)
     {
-        return $data;
+        return $data ?: [];
     }
 
     /**

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -40,9 +40,11 @@ abstract class SerializerAbstract
     /**
      * Serialize null resource.
      *
-     * @return array
+     * @param string $resourceKey
+     *
+     * @return array|null
      */
-    abstract public function null();
+    abstract public function null($resourceKey);
 
     /**
      * Serialize the included data.

--- a/test/Serializer/ExplicitNullArraySerializerTest.php
+++ b/test/Serializer/ExplicitNullArraySerializerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace Serializer;
+
+
+use League\Fractal\Manager;
+use League\Fractal\Resource\NullResource;
+use League\Fractal\Scope;
+use League\Fractal\Serializer\ExplicitNullArraySerializer;
+use League\Fractal\Test\Stub\Transformer\GenericBookTransformer;
+
+class ExplicitNullArraySerializerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSerializingNullResource()
+    {
+        $manager = new Manager();
+        $manager->parseIncludes('author');
+        $manager->setSerializer(new ExplicitNullArraySerializer());
+
+        $resource = new NullResource(null, new GenericBookTransformer(), 'books');
+
+        // Try without metadata
+        $scope = new Scope($manager, $resource);
+
+        $expected = null;
+        $this->assertSame($expected, $scope->toArray());
+
+        // JSON array of JSON objects
+        $expectedJson = 'null';
+        $this->assertSame($expectedJson, $scope->toJson());
+
+        // Same again with metadata
+        $resource->setMetaValue('foo', 'bar');
+        $scope = new Scope($manager, $resource);
+
+        $expected = null;
+        $this->assertSame($expected, $scope->toArray());
+
+        $expectedJson = 'null';
+        $this->assertSame($expectedJson, $scope->toJson());
+    }
+}


### PR DESCRIPTION
A null resource can have a resourceKey so added to all serializers.

In case `ExplicitNullArraySerializer` is used, with null resource, meta will not be available as a null value is returned.

This modification will break BC, so Fractal should be bumped to 0.14.0 (or 1.0.0?)
