### PR TITLE
Introduce Scope Factory

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -73,6 +73,11 @@ class Manager
      */
     private $scopeFactory;
 
+    public function __construct(ScopeFactoryInterface $scopeFactory = null)
+    {
+        $this->scopeFactory = $scopeFactory ?: new ScopeFactory();
+    }
+
     /**
      * Create Data.
      *
@@ -87,10 +92,10 @@ class Manager
     public function createData(ResourceInterface $resource, $scopeIdentifier = null, Scope $parentScopeInstance = null)
     {
         if ($parentScopeInstance !== null) {
-            return $this->getScopeFactory()->createChildScopeFor($parentScopeInstance, $resource, $scopeIdentifier);
+            return $this->scopeFactory->createChildScopeFor($this, $parentScopeInstance, $resource, $scopeIdentifier);
         }
 
-        return $this->getScopeFactory()->createScopeFor($resource, $scopeIdentifier);
+        return $this->scopeFactory->createScopeFor($this, $resource, $scopeIdentifier);
     }
 
     /**
@@ -266,32 +271,6 @@ class Manager
     public function setSerializer(SerializerAbstract $serializer)
     {
         $this->serializer = $serializer;
-
-        return $this;
-    }
-
-    /**
-     * @return ScopeFactoryInterface
-     */
-    public function getScopeFactory()
-    {
-        if (!$this->scopeFactory) {
-            $this->scopeFactory = new ScopeFactory($this);
-        }
-
-        return $this->scopeFactory;
-    }
-
-    /**
-     * Set ScopeFactory
-     *
-     * @param ScopeFactoryInterface $scopeFactory
-     *
-     * @return $this
-     */
-    public function setScopeFactory(ScopeFactoryInterface $scopeFactory)
-    {
-        $this->scopeFactory = $scopeFactory;
 
         return $this;
     }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -67,6 +67,13 @@ class Manager
     protected $serializer;
 
     /**
+     * Factory used to create new configured scopes.
+     *
+     * @var ScopeFactoryInterface
+     */
+    private $scopeFactory;
+
+    /**
      * Create Data.
      *
      * Main method to kick this all off. Make a resource then pass it over, and use toArray()
@@ -79,18 +86,11 @@ class Manager
      */
     public function createData(ResourceInterface $resource, $scopeIdentifier = null, Scope $parentScopeInstance = null)
     {
-        $scopeInstance = new Scope($this, $resource, $scopeIdentifier);
-
-        // Update scope history
         if ($parentScopeInstance !== null) {
-            // This will be the new children list of parents (parents parents, plus the parent)
-            $scopeArray = $parentScopeInstance->getParentScopes();
-            $scopeArray[] = $parentScopeInstance->getScopeIdentifier();
-
-            $scopeInstance->setParentScopes($scopeArray);
+            return $this->getScopeFactory()->createChildScopeFor($parentScopeInstance, $resource, $scopeIdentifier);
         }
 
-        return $scopeInstance;
+        return $this->getScopeFactory()->createScopeFor($resource, $scopeIdentifier);
     }
 
     /**
@@ -266,6 +266,32 @@ class Manager
     public function setSerializer(SerializerAbstract $serializer)
     {
         $this->serializer = $serializer;
+
+        return $this;
+    }
+
+    /**
+     * @return ScopeFactoryInterface
+     */
+    public function getScopeFactory()
+    {
+        if (!$this->scopeFactory) {
+            $this->scopeFactory = new ScopeFactory($this);
+        }
+
+        return $this->scopeFactory;
+    }
+
+    /**
+     * Set ScopeFactory
+     *
+     * @param ScopeFactoryInterface $scopeFactory
+     *
+     * @return $this
+     */
+    public function setScopeFactory(ScopeFactoryInterface $scopeFactory)
+    {
+        $this->scopeFactory = $scopeFactory;
 
         return $this;
     }

--- a/src/ScopeFactory.php
+++ b/src/ScopeFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the League\Fractal package.
+ *
+ * (c) Phil Sturgeon <me@philsturgeon.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\Fractal;
+
+use League\Fractal\Resource\ResourceInterface;
+
+class ScopeFactory implements ScopeFactoryInterface
+{
+    /**
+     * @var Manager
+     */
+    private $manager;
+
+    public function __construct(Manager $manager)
+    {
+        $this->manager = $manager;
+    }
+
+    /**
+     * @param ResourceInterface $resource
+     * @param string|null $scopeIdentifier
+     * @return Scope
+     */
+    public function createScopeFor(ResourceInterface $resource, $scopeIdentifier = null)
+    {
+        return new Scope($this->manager, $resource, $scopeIdentifier);
+    }
+
+    /**
+     * @param Scope $parentScopeInstance
+     * @param ResourceInterface $resource
+     * @param string|null $scopeIdentifier
+     * @return Scope
+     */
+    public function createChildScopeFor(Scope $parentScopeInstance, ResourceInterface $resource, $scopeIdentifier = null)
+    {
+        $scopeInstance = $this->createScopeFor($resource, $scopeIdentifier);
+
+        // This will be the new children list of parents (parents parents, plus the parent)
+        $scopeArray = $parentScopeInstance->getParentScopes();
+        $scopeArray[] = $parentScopeInstance->getScopeIdentifier();
+
+        $scopeInstance->setParentScopes($scopeArray);
+
+        return $scopeInstance;
+    }
+}

--- a/src/ScopeFactory.php
+++ b/src/ScopeFactory.php
@@ -16,34 +16,26 @@ use League\Fractal\Resource\ResourceInterface;
 class ScopeFactory implements ScopeFactoryInterface
 {
     /**
-     * @var Manager
-     */
-    private $manager;
-
-    public function __construct(Manager $manager)
-    {
-        $this->manager = $manager;
-    }
-
-    /**
+     * @param Manager $manager
      * @param ResourceInterface $resource
      * @param string|null $scopeIdentifier
      * @return Scope
      */
-    public function createScopeFor(ResourceInterface $resource, $scopeIdentifier = null)
+    public function createScopeFor(Manager $manager, ResourceInterface $resource, $scopeIdentifier = null)
     {
-        return new Scope($this->manager, $resource, $scopeIdentifier);
+        return new Scope($manager, $resource, $scopeIdentifier);
     }
 
     /**
+     * @param Manager $manager
      * @param Scope $parentScopeInstance
      * @param ResourceInterface $resource
      * @param string|null $scopeIdentifier
      * @return Scope
      */
-    public function createChildScopeFor(Scope $parentScopeInstance, ResourceInterface $resource, $scopeIdentifier = null)
+    public function createChildScopeFor(Manager $manager, Scope $parentScopeInstance, ResourceInterface $resource, $scopeIdentifier = null)
     {
-        $scopeInstance = $this->createScopeFor($resource, $scopeIdentifier);
+        $scopeInstance = $this->createScopeFor($manager, $resource, $scopeIdentifier);
 
         // This will be the new children list of parents (parents parents, plus the parent)
         $scopeArray = $parentScopeInstance->getParentScopes();

--- a/src/ScopeFactoryInterface.php
+++ b/src/ScopeFactoryInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the League\Fractal package.
+ *
+ * (c) Phil Sturgeon <me@philsturgeon.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\Fractal;
+
+use League\Fractal\Resource\ResourceInterface;
+
+/**
+ * ScopeFactoryInterface
+ *
+ * Creates Scope Instances for resources
+ */
+interface ScopeFactoryInterface
+{
+    /**
+     * @param ResourceInterface $resource
+     * @param string|null $scopeIdentifier
+     * @return Scope
+     */
+    public function createScopeFor(ResourceInterface $resource, $scopeIdentifier = null);
+
+    /**
+     * @param Scope $parentScope
+     * @param ResourceInterface $resource
+     * @param string|null $scopeIdentifier
+     * @return Scope
+     */
+    public function createChildScopeFor(Scope $parentScope, ResourceInterface $resource, $scopeIdentifier = null);
+}

--- a/src/ScopeFactoryInterface.php
+++ b/src/ScopeFactoryInterface.php
@@ -21,17 +21,19 @@ use League\Fractal\Resource\ResourceInterface;
 interface ScopeFactoryInterface
 {
     /**
+     * @param Manager $manager
      * @param ResourceInterface $resource
      * @param string|null $scopeIdentifier
      * @return Scope
      */
-    public function createScopeFor(ResourceInterface $resource, $scopeIdentifier = null);
+    public function createScopeFor(Manager $manager, ResourceInterface $resource, $scopeIdentifier = null);
 
     /**
+     * @param Manager $manager
      * @param Scope $parentScope
      * @param ResourceInterface $resource
      * @param string|null $scopeIdentifier
      * @return Scope
      */
-    public function createChildScopeFor(Scope $parentScope, ResourceInterface $resource, $scopeIdentifier = null);
+    public function createChildScopeFor(Manager $manager, Scope $parentScope, ResourceInterface $resource, $scopeIdentifier = null);
 }

--- a/test/ScopeFactoryTest.php
+++ b/test/ScopeFactoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace League\Fractal\Test;
+
+use League\Fractal\Manager;
+use League\Fractal\Resource\ResourceInterface;
+use League\Fractal\Scope;
+use League\Fractal\ScopeFactory;
+
+class ScopeFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testItImplementsScopeFactoryInterface()
+    {
+        $this->assertInstanceOf('League\\Fractal\\ScopeFactoryInterface', $this->createSut());
+    }
+
+    public function testItCreatesScopes()
+    {
+        $sut = $this->createSut();
+
+        $resource = $this->createResource();
+        $scopeIdentifier = 'foo_identifier';
+
+        $scope = $sut->createScopeFor($resource, $scopeIdentifier);
+
+        $this->assertInstanceOf('League\\Fractal\\Scope', $scope);
+        $this->assertSame($resource, $scope->getResource());
+        $this->assertSame($scopeIdentifier, $scope->getScopeIdentifier());
+    }
+
+    public function testItCreatesScopesWithParent()
+    {
+        $manager = $this->createManager();
+
+        $scope = new Scope($manager, $this->createResource(), 'parent_identifier');
+        $scope->setParentScopes([
+            'parent_scope',
+        ]);
+
+        $resource = $this->createResource();
+        $scopeIdentifier = 'foo_identifier';
+
+        $expectedParentScopes = [
+            'parent_scope',
+            'parent_identifier',
+        ];
+
+        $sut = $this->createSut($manager);
+        $scope = $sut->createChildScopeFor($scope, $resource, $scopeIdentifier);
+
+        $this->assertInstanceOf('League\\Fractal\\Scope', $scope);
+        $this->assertSame($resource, $scope->getResource());
+        $this->assertSame($scopeIdentifier, $scope->getScopeIdentifier());
+        $this->assertEquals($expectedParentScopes, $scope->getParentScopes());
+    }
+
+    /**
+     * @param Manager $manager
+     * @return ScopeFactory
+     */
+    private function createSut(Manager $manager = null)
+    {
+        if ($manager === null) {
+            $manager = $this->createManager();
+        }
+
+        return new ScopeFactory($manager);
+    }
+
+    /**
+     * @return Manager
+     */
+    private function createManager()
+    {
+        return $this->getMock('League\\Fractal\\Manager');
+    }
+
+    /**
+     * @return ResourceInterface
+     */
+    private function createResource()
+    {
+        return $this->getMock('League\\Fractal\\Resource\\ResourceInterface');
+    }
+}

--- a/test/ScopeFactoryTest.php
+++ b/test/ScopeFactoryTest.php
@@ -18,10 +18,11 @@ class ScopeFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $sut = $this->createSut();
 
+        $manager = $this->createManager();
         $resource = $this->createResource();
         $scopeIdentifier = 'foo_identifier';
 
-        $scope = $sut->createScopeFor($resource, $scopeIdentifier);
+        $scope = $sut->createScopeFor($manager, $resource, $scopeIdentifier);
 
         $this->assertInstanceOf('League\\Fractal\\Scope', $scope);
         $this->assertSame($resource, $scope->getResource());
@@ -45,8 +46,8 @@ class ScopeFactoryTest extends \PHPUnit_Framework_TestCase
             'parent_identifier',
         ];
 
-        $sut = $this->createSut($manager);
-        $scope = $sut->createChildScopeFor($scope, $resource, $scopeIdentifier);
+        $sut = $this->createSut();
+        $scope = $sut->createChildScopeFor($manager, $scope, $resource, $scopeIdentifier);
 
         $this->assertInstanceOf('League\\Fractal\\Scope', $scope);
         $this->assertSame($resource, $scope->getResource());
@@ -55,16 +56,11 @@ class ScopeFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param Manager $manager
      * @return ScopeFactory
      */
-    private function createSut(Manager $manager = null)
+    private function createSut()
     {
-        if ($manager === null) {
-            $manager = $this->createManager();
-        }
-
-        return new ScopeFactory($manager);
+        return new ScopeFactory();
     }
 
     /**


### PR DESCRIPTION
I have a use case where I wish to profile serialization. I want to log all calls to transformers. To do this, I need to inject my logging scopes.

This PR introduces a scope factory interface to properly generate configured scope instances. When not injected, a default factory is created which has the same behavior as current `Manager::createData` implementation.
