### PR TITLE
Adding missing rawurldecode to fix broken pagination links

### DIFF
--- a/src/Pagination/IlluminatePaginatorAdapter.php
+++ b/src/Pagination/IlluminatePaginatorAdapter.php
@@ -99,7 +99,7 @@ class IlluminatePaginatorAdapter implements PaginatorInterface
      */
     public function getUrl($page)
     {
-        return $this->paginator->url($page);
+        return rawurldecode($this->paginator->url($page));
     }
 
     /**


### PR DESCRIPTION
Without the `rawurldecode` if the you add something to the url, like parameters using the `appends` the url is encoded, so that it does not work. 

Without it e.g. `filter[id]` will be `filter%5Bid%5D`.