### PR TITLE
Fix when nullResource returned from Transformers

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -273,6 +273,14 @@ class Scope
         // Pull out all of OUR metadata and any custom meta data to merge with the main level data
         $meta = $serializer->meta($this->resource->getMeta());
 
+        // in case of returning NullResource we should return null and not to go with array_merge
+        if (is_null($data)) {
+            if (!empty($meta)) {
+                return $meta;
+            }
+            return null;
+        }
+
         return array_merge($data, $meta);
     }
 

--- a/src/Serializer/ArraySerializerWithNull.php
+++ b/src/Serializer/ArraySerializerWithNull.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace League\Fractal\Serializer;
+
+class ArraySerializerWithNull extends ArraySerializer
+{
+    /**
+     * Serialize null resource.
+     *
+     * @return null
+     */
+    public function null()
+    {
+        return null;
+    }
+}

--- a/test/ScopeTest.php
+++ b/test/ScopeTest.php
@@ -7,7 +7,7 @@ use League\Fractal\Resource\Item;
 use League\Fractal\Resource\NullResource;
 use League\Fractal\Scope;
 use League\Fractal\Serializer\ArraySerializer;
-use League\Fractal\Serializer\ArraySerializerWithNull;
+use League\Fractal\Test\Stub\ArraySerializerWithNull;
 use League\Fractal\Test\Stub\Transformer\DefaultIncludeBookTransformer;
 use League\Fractal\Test\Stub\Transformer\NullIncludeBookTransformer;
 use Mockery;

--- a/test/ScopeTest.php
+++ b/test/ScopeTest.php
@@ -4,9 +4,12 @@ use League\Fractal\Manager;
 use League\Fractal\Pagination\Cursor;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
+use League\Fractal\Resource\NullResource;
 use League\Fractal\Scope;
 use League\Fractal\Serializer\ArraySerializer;
+use League\Fractal\Serializer\ArraySerializerWithNull;
 use League\Fractal\Test\Stub\Transformer\DefaultIncludeBookTransformer;
+use League\Fractal\Test\Stub\Transformer\NullIncludeBookTransformer;
 use Mockery;
 
 class ScopeTest extends \PHPUnit_Framework_TestCase
@@ -50,7 +53,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Scope::toArray
+     * @covers \League\Fractal\Scope::toArray
      */
     public function testToArray()
     {
@@ -299,7 +302,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Scope::executeResourceTransformers
+     * @covers \League\Fractal\Scope::executeResourceTransformers
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Argument $resource should be an instance of League\Fractal\Resource\Item or League\Fractal\Resource\Collection
      */
@@ -426,6 +429,40 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->assertSame($expected, $scope->toArray());
+    }
+
+    public function testNullResourceIncludeSuccess()
+    {
+        $manager = new Manager();
+        $manager->setSerializer(new ArraySerializerWithNull);
+
+        // Send this stub junk, it has a specific format anyhow
+        $resource = new Item([], new NullIncludeBookTransformer);
+
+        // Try without metadata
+        $scope = new Scope($manager, $resource);
+        $expected = [
+            'a' => 'b',
+            'author' => null,
+        ];
+
+        $this->assertSame($expected, $scope->toArray());
+    }
+
+    /**
+     * @covers \League\Fractal\Scope::toArray
+     */
+    public function testNullResourceDataAndJustMeta()
+    {
+        $manager = new Manager();
+        $manager->setSerializer(new ArraySerializerWithNull);
+
+        $resource = new NullResource();
+        $resource->setMeta(['foo' => 'bar']);
+
+        $scope = new Scope($manager, $resource);
+
+        $this->assertSame(['meta' => ['foo' => 'bar']], $scope->toArray());
     }
 
     public function tearDown()

--- a/test/Stub/ArraySerializerWithNull.php
+++ b/test/Stub/ArraySerializerWithNull.php
@@ -1,7 +1,9 @@
 <?php
 
 
-namespace League\Fractal\Serializer;
+namespace League\Fractal\Test\Stub;
+
+use League\Fractal\Serializer\ArraySerializer;
 
 class ArraySerializerWithNull extends ArraySerializer
 {

--- a/test/Stub/Transformer/NullIncludeBookTransformer.php
+++ b/test/Stub/Transformer/NullIncludeBookTransformer.php
@@ -1,0 +1,20 @@
+<?php namespace League\Fractal\Test\Stub\Transformer;
+
+use League\Fractal\TransformerAbstract;
+
+class NullIncludeBookTransformer extends TransformerAbstract
+{
+    protected $defaultIncludes = [
+        'author',
+    ];
+
+    public function transform()
+    {
+        return ['a' => 'b'];
+    }
+
+    public function includeAuthor()
+    {
+        return $this->null();
+    }
+}


### PR DESCRIPTION
This fix is needed in case of returning NullResource and return null.
In case of meta is not empty we will return meta array
