### PR TITLE
Add links for all available includes to JsonApiSerializer

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -258,6 +258,10 @@ class Scope
             $data = array_merge($data, $includedData);
         }
 
+        if (!empty($this->availableIncludes)) {
+            $data = $serializer->injectAvailableIncludeData($data, $this->availableIncludes);
+        }
+
         if ($this->resource instanceof Collection) {
             if ($this->resource->hasCursor()) {
                 $pagination = $serializer->cursor($this->resource->getCursor());

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -600,7 +600,8 @@ class JsonApiSerializer extends ArraySerializer
 
         return $resource;
     }
-  
+
+    /**
      * @param $includeObjects
      * @param $linkedIds
      * @param $serializedData

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -464,15 +464,6 @@ class JsonApiSerializer extends ArraySerializer
     {
         foreach ($relationship as $index => $relationshipData) {
             $data['data'][$index]['relationships'][$key] = $relationshipData;
-
-            if ($this->shouldIncludeLinks()) {
-                $data['data'][$index]['relationships'][$key] = array_merge([
-                    'links' => [
-                        'self' => "{$this->baseUrl}/{$data['data'][$index]['type']}/{$data['data'][$index]['id']}/relationships/$key",
-                        'related' => "{$this->baseUrl}/{$data['data'][$index]['type']}/{$data['data'][$index]['id']}/$key",
-                    ],
-                ], $data['data'][$index]['relationships'][$key]);
-            }
         }
 
         return $data;
@@ -490,16 +481,6 @@ class JsonApiSerializer extends ArraySerializer
     {
         $data['data']['relationships'][$key] = $relationship[0];
 
-        if ($this->shouldIncludeLinks()) {
-            $data['data']['relationships'][$key] = array_merge([
-                'links' => [
-                    'self' => "{$this->baseUrl}/{$data['data']['type']}/{$data['data']['id']}/relationships/$key",
-                    'related' => "{$this->baseUrl}/{$data['data']['type']}/{$data['data']['id']}/$key",
-                ],
-            ], $data['data']['relationships'][$key]);
-
-            return $data;
-        }
         return $data;
     }
 
@@ -571,5 +552,55 @@ class JsonApiSerializer extends ArraySerializer
         }
 
         return $relationship;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function injectAvailableIncludeData($data, $availableIncludes)
+    {
+        if (!$this->shouldIncludeLinks()) {
+            return $data;
+        }
+
+        if ($this->isCollection($data)) {
+            $data['data'] = array_map(function ($resource) use ($availableIncludes) {
+                foreach ($availableIncludes as $relationshipKey) {
+                    $resource = $this->addRelationshipLinks($resource, $relationshipKey);
+                }
+                return $resource;
+            }, $data['data']);
+        } else {
+            foreach ($availableIncludes as $relationshipKey) {
+                $data['data'] = $this->addRelationshipLinks($data['data'], $relationshipKey);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Adds links for all available includes to a single resource.
+     *
+     * @param array $resource         The resource to add relationship links to
+     * @param string $relationshipKey The resource key of the relationship
+     */
+    private function addRelationshipLinks($resource, $relationshipKey)
+    {
+        if (!isset($resource['relationships']) || !isset($resource['relationships'][$relationshipKey])) {
+            $resource['relationships'][$relationshipKey] = [];
+        }
+
+        $resource['relationships'][$relationshipKey] = array_merge(
+            [
+                'links' => [
+                    'self'   => "{$this->baseUrl}/{$resource['type']}/{$resource['id']}/relationships/{$relationshipKey}",
+                    'related' => "{$this->baseUrl}/{$resource['type']}/{$resource['id']}/{$relationshipKey}",
+                ]
+            ],
+            $resource['relationships'][$relationshipKey]
+        );
+
+        return $resource;
     }
 }

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -116,6 +116,19 @@ abstract class SerializerAbstract
     }
 
     /**
+     * Hook for the serializer to inject custom data based on the available includes of the resource.
+     *
+     * @param array $data
+     * @param array $availableIncludes
+     *
+     * @return array
+     */
+    public function injectAvailableIncludeData($data, $availableIncludes)
+    {
+        return $data;
+    }
+
+    /**
      * Hook for the serializer to modify the final list of includes.
      *
      * @param array             $includedData

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -1012,12 +1012,26 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                 'links' => [
                     'self' => 'http://example.com/books/1',
                 ],
+                'relationships' => [
+                    'author' => [
+                        'links' => [
+                            'self' => 'http://example.com/books/1/relationships/author',
+                            'related' => 'http://example.com/books/1/author',
+                        ],
+                    ],
+                    'co-author' => [
+                        'links' => [
+                            'self' => 'http://example.com/books/1/relationships/co-author',
+                            'related' => 'http://example.com/books/1/co-author',
+                        ],
+                    ],
+                ],
             ],
         ];
 
         $this->assertSame($expected, $scope->toArray());
 
-        $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"}}}';
+        $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}}}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1062,6 +1076,20 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     'links' => [
                         'self' => 'http://example.com/books/1',
                     ],
+                    'relationships' => [
+                        'author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author',
+                                'related' => 'http://example.com/books/1/author',
+                            ],
+                        ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/co-author',
+                                'related' => 'http://example.com/books/1/co-author',
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'type' => 'books',
@@ -1073,13 +1101,27 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     'links' => [
                         'self' => 'http://example.com/books/2',
                     ],
+                    'relationships' => [
+                        'author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author',
+                                'related' => 'http://example.com/books/2/author'
+                            ],
+                        ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/co-author',
+                                'related' => 'http://example.com/books/2/co-author'
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ];
 
         $this->assertSame($expected, $scope->toArray());
 
-        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"}}]}';
+        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}]}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1122,6 +1164,12 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                             'id' => '1',
                         ],
                     ],
+                    'co-author' => [
+                        'links' => [
+                            'self' => 'http://example.com/books/1/relationships/co-author',
+                            'related' => 'http://example.com/books/1/co-author'
+                        ],
+                    ],
                 ],
                 'links' => [
                     'self' => 'http://example.com/books/1',
@@ -1134,6 +1182,14 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     'attributes' => [
                         'name' => 'Dave',
                     ],
+                    'relationships' => [
+                        'published' => [
+                            'links' => [
+                                'self' => 'http://example.com/people/1/relationships/published',
+                                'related' => 'http://example.com/people/1/published',
+                            ],
+                        ],
+                    ],
                     'links' => [
                         'self' => 'http://example.com/people/1',
                     ],
@@ -1143,7 +1199,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"},"data":{"type":"people","id":"1"}}}},"included":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"}}]}';
+        $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"},"data":{"type":"people","id":"1"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},"included":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"}}}}]}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1214,6 +1270,20 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     'links' => [
                         'self' => 'http://example.com/books/1',
                     ],
+                    'relationships' => [
+                        'author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author',
+                                'related' => 'http://example.com/books/1/author'
+                            ],
+                        ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/co-author',
+                                'related' => 'http://example.com/books/1/co-author'
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'type' => 'books',
@@ -1225,13 +1295,27 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     'links' => [
                         'self' => 'http://example.com/books/2',
                     ],
+                    'relationships' => [
+                        'author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author',
+                                'related' => 'http://example.com/books/2/author'
+                            ],
+                        ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/co-author',
+                                'related' => 'http://example.com/books/2/co-author'
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ];
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"data":{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},"included":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015},"links":{"self":"http:\/\/example.com\/books\/2"}}]}';
+        $expectedJson = '{"data":{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},"included":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}]}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1286,6 +1370,12 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                                 'id' => '1',
                             ],
                         ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/co-author',
+                                'related' => 'http://example.com/books/1/co-author'
+                            ],
+                        ],
                     ],
                     'links' => [
                         'self' => 'http://example.com/books/1',
@@ -1309,6 +1399,12 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                                 'id' => '1',
                             ],
                         ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/co-author',
+                                'related' => 'http://example.com/books/2/co-author'
+                            ],
+                        ],
                     ],
                     'links' => [
                         'self' => 'http://example.com/books/2',
@@ -1325,13 +1421,21 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     'links' => [
                         'self' => 'http://example.com/people/1',
                     ],
+                    'relationships' => [
+                        'published' => [
+                            'links' => [
+                                'self' => 'http://example.com/people/1/relationships/published',
+                                'related' => 'http://example.com/people/1/published',
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ];
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"},"data":{"type":"people","id":"1"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1991},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"},"data":{"type":"people","id":"1"}}}}],"included":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"}}]}';
+        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"},"data":{"type":"people","id":"1"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1991},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"},"data":{"type":"people","id":"1"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}],"included":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"}}}}]}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1450,6 +1554,20 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     'links' => [
                         'self' => 'http://example.com/books/1',
                     ],
+                    'relationships' => [
+                        'author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author',
+                                'related' => 'http://example.com/books/1/author',
+                            ],
+                        ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/co-author',
+                                'related' => 'http://example.com/books/1/co-author'
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'type' => 'books',
@@ -1461,13 +1579,27 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     'links' => [
                         'self' => 'http://example.com/books/2',
                     ],
+                    'relationships' => [
+                        'author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author',
+                                'related' => 'http://example.com/books/2/author',
+                            ],
+                        ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/co-author',
+                                'related' => 'http://example.com/books/2/co-author'
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ];
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"data":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},{"type":"people","id":"2","attributes":{"name":"Bill"},"links":{"self":"http:\/\/example.com\/people\/2"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/2\/relationships\/published","related":"http:\/\/example.com\/people\/2\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}}],"included":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015},"links":{"self":"http:\/\/example.com\/books\/2"}}]}';
+        $expectedJson = '{"data":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},{"type":"people","id":"2","attributes":{"name":"Bill"},"links":{"self":"http:\/\/example.com\/people\/2"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/2\/relationships\/published","related":"http:\/\/example.com\/people\/2\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}}],"included":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}]}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1743,6 +1875,20 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     'links' => [
                         'self' => 'http://example.com/books/1',
                     ],
+                    'relationships' => [
+                        'author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author',
+                                'related' => 'http://example.com/books/1/author',
+                            ],
+                        ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/co-author',
+                                'related' => 'http://example.com/books/1/co-author'
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'type' => 'books',
@@ -1753,6 +1899,20 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     ],
                     'links' => [
                         'self' => 'http://example.com/books/2',
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author',
+                                'related' => 'http://example.com/books/2/author',
+                            ],
+                        ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/co-author',
+                                'related' => 'http://example.com/books/2/co-author'
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -1776,7 +1936,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $scope->toArray());
 
-        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":2,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=2","first":"http:\/\/example.com\/books\/?page=1","prev":"http:\/\/example.com\/books\/?page=1","next":"http:\/\/example.com\/books\/?page=3","last":"http:\/\/example.com\/books\/?page=5"}}';
+        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":2,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=2","first":"http:\/\/example.com\/books\/?page=1","prev":"http:\/\/example.com\/books\/?page=1","next":"http:\/\/example.com\/books\/?page=3","last":"http:\/\/example.com\/books\/?page=5"}}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1842,6 +2002,20 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     'links' => [
                         'self' => 'http://example.com/books/1',
                     ],
+                    'relationships' => [
+                        'author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author',
+                                'related' => 'http://example.com/books/1/author',
+                            ],
+                        ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/co-author',
+                                'related' => 'http://example.com/books/1/co-author'
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'type' => 'books',
@@ -1852,6 +2026,20 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     ],
                     'links' => [
                         'self' => 'http://example.com/books/2',
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author',
+                                'related' => 'http://example.com/books/2/author',
+                            ],
+                        ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/co-author',
+                                'related' => 'http://example.com/books/2/co-author'
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -1874,7 +2062,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $scope->toArray());
 
-        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":1,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=1","first":"http:\/\/example.com\/books\/?page=1","next":"http:\/\/example.com\/books\/?page=2","last":"http:\/\/example.com\/books\/?page=5"}}';
+        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":1,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=1","first":"http:\/\/example.com\/books\/?page=1","next":"http:\/\/example.com\/books\/?page=2","last":"http:\/\/example.com\/books\/?page=5"}}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1940,6 +2128,20 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     'links' => [
                         'self' => 'http://example.com/books/1',
                     ],
+                    'relationships' => [
+                        'author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author',
+                                'related' => 'http://example.com/books/1/author',
+                            ],
+                        ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/co-author',
+                                'related' => 'http://example.com/books/1/co-author'
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'type' => 'books',
@@ -1950,6 +2152,20 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                     ],
                     'links' => [
                         'self' => 'http://example.com/books/2',
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author',
+                                'related' => 'http://example.com/books/2/author',
+                            ],
+                        ],
+                        'co-author' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/co-author',
+                                'related' => 'http://example.com/books/2/co-author'
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -1972,7 +2188,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $scope->toArray());
 
-        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":5,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=5","first":"http:\/\/example.com\/books\/?page=1","prev":"http:\/\/example.com\/books\/?page=4","last":"http:\/\/example.com\/books\/?page=5"}}';
+        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":5,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=5","first":"http:\/\/example.com\/books\/?page=1","prev":"http:\/\/example.com\/books\/?page=4","last":"http:\/\/example.com\/books\/?page=5"}}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -2009,7 +2225,21 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                 'links' => [
                     'custom_link' => '/custom/link',
                     'self' => 'http://test.de/books/1',
-                ]
+                ],
+                'relationships' => [
+                    'author' => [
+                        'links' => [
+                            'self' => 'http://test.de/books/1/relationships/author',
+                            'related' => 'http://test.de/books/1/author',
+                        ],
+                    ],
+                    'co-author' => [
+                        'links' => [
+                            'self' => 'http://test.de/books/1/relationships/co-author',
+                            'related' => 'http://test.de/books/1/co-author'
+                        ],
+                    ],
+                ],
             ],
         ];
 
@@ -2045,7 +2275,21 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
                 ],
                 'links' => [
                     'self' => 'http://test.de/books/1',
-                ]
+                ],
+                'relationships' => [
+                    'author' => [
+                        'links' => [
+                            'self' => 'http://test.de/books/1/relationships/author',
+                            'related' => 'http://test.de/books/1/author',
+                        ],
+                    ],
+                    'co-author' => [
+                        'links' => [
+                            'self' => 'http://test.de/books/1/relationships/co-author',
+                            'related' => 'http://test.de/books/1/co-author'
+                        ],
+                    ],
+                ],
             ],
         ];
 

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -1189,13 +1189,19 @@ class JsonApiSerializerTest extends TestCase
                             'related' => 'http://example.com/books/1/co-author',
                         ],
                     ],
+                    'author-with-meta' => [
+                        'links' => [
+                            'self' => 'http://example.com/books/1/relationships/author-with-meta',
+                            'related' => 'http://example.com/books/1/author-with-meta',
+                        ],
+                    ],
                 ],
             ],
         ];
 
         $this->assertSame($expected, $scope->toArray());
 
-        $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}}}';
+        $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/1\/author-with-meta"}}}}}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1253,6 +1259,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/1/co-author',
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/1/author-with-meta',
+                            ],
+                        ],
                     ],
                 ],
                 [
@@ -1278,6 +1290,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/2/co-author'
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/2/author-with-meta',
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -1285,7 +1303,7 @@ class JsonApiSerializerTest extends TestCase
 
         $this->assertSame($expected, $scope->toArray());
 
-        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}]}';
+        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/1\/author-with-meta"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/2\/author-with-meta"}}}}]}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1334,6 +1352,12 @@ class JsonApiSerializerTest extends TestCase
                             'related' => 'http://example.com/books/1/co-author'
                         ],
                     ],
+                    'author-with-meta' => [
+                        'links' => [
+                            'self' => 'http://example.com/books/1/relationships/author-with-meta',
+                            'related' => 'http://example.com/books/1/author-with-meta'
+                        ],
+                    ],
                 ],
                 'links' => [
                     'self' => 'http://example.com/books/1',
@@ -1363,7 +1387,7 @@ class JsonApiSerializerTest extends TestCase
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"},"data":{"type":"people","id":"1"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},"included":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"}}}}]}';
+        $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"},"data":{"type":"people","id":"1"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/1\/author-with-meta"}}}},"included":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"}}}}]}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1447,6 +1471,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/1/co-author'
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/1/author-with-meta'
+                            ],
+                        ],
                     ],
                 ],
                 [
@@ -1472,6 +1502,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/2/co-author'
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/2/author-with-meta'
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -1479,7 +1515,7 @@ class JsonApiSerializerTest extends TestCase
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"data":{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},"included":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}]}';
+        $expectedJson = '{"data":{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},"included":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/1\/author-with-meta"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/2\/author-with-meta"}}}}]}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1540,6 +1576,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/1/co-author'
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/1/author-with-meta'
+                            ],
+                        ],
                     ],
                     'links' => [
                         'self' => 'http://example.com/books/1',
@@ -1567,6 +1609,12 @@ class JsonApiSerializerTest extends TestCase
                             'links' => [
                                 'self' => 'http://example.com/books/2/relationships/co-author',
                                 'related' => 'http://example.com/books/2/co-author'
+                            ],
+                        ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/2/author-with-meta'
                             ],
                         ],
                     ],
@@ -1599,7 +1647,7 @@ class JsonApiSerializerTest extends TestCase
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"},"data":{"type":"people","id":"1"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1991},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"},"data":{"type":"people","id":"1"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}],"included":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"}}}}]}';
+        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"},"data":{"type":"people","id":"1"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/1\/author-with-meta"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1991},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"},"data":{"type":"people","id":"1"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/2\/author-with-meta"}}}}],"included":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"}}}}]}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -1731,6 +1779,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/1/co-author'
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/1/author-with-meta'
+                            ],
+                        ],
                     ],
                 ],
                 [
@@ -1756,6 +1810,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/2/co-author'
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/2/author-with-meta'
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -1763,7 +1823,7 @@ class JsonApiSerializerTest extends TestCase
 
         $this->assertEquals($expected, $scope->toArray());
 
-        $expectedJson = '{"data":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},{"type":"people","id":"2","attributes":{"name":"Bill"},"links":{"self":"http:\/\/example.com\/people\/2"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/2\/relationships\/published","related":"http:\/\/example.com\/people\/2\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}}],"included":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}]}';
+        $expectedJson = '{"data":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/1\/relationships\/published","related":"http:\/\/example.com\/people\/1\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},{"type":"people","id":"2","attributes":{"name":"Bill"},"links":{"self":"http:\/\/example.com\/people\/2"},"relationships":{"published":{"links":{"self":"http:\/\/example.com\/people\/2\/relationships\/published","related":"http:\/\/example.com\/people\/2\/published"},"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}}],"included":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/1\/author-with-meta"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/2\/author-with-meta"}}}}]}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -2052,6 +2112,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/1/co-author'
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/1/author-with-meta'
+                            ],
+                        ],
                     ],
                 ],
                 [
@@ -2077,6 +2143,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/2/co-author'
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/2/author-with-meta'
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -2100,7 +2172,7 @@ class JsonApiSerializerTest extends TestCase
 
         $this->assertSame($expected, $scope->toArray());
 
-        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":2,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=2","first":"http:\/\/example.com\/books\/?page=1","prev":"http:\/\/example.com\/books\/?page=1","next":"http:\/\/example.com\/books\/?page=3","last":"http:\/\/example.com\/books\/?page=5"}}';
+        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/1\/author-with-meta"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/2\/author-with-meta"}}}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":2,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=2","first":"http:\/\/example.com\/books\/?page=1","prev":"http:\/\/example.com\/books\/?page=1","next":"http:\/\/example.com\/books\/?page=3","last":"http:\/\/example.com\/books\/?page=5"}}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -2179,6 +2251,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/1/co-author'
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/1/author-with-meta'
+                            ],
+                        ],
                     ],
                 ],
                 [
@@ -2204,6 +2282,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/2/co-author'
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/2/author-with-meta'
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -2226,7 +2310,7 @@ class JsonApiSerializerTest extends TestCase
 
         $this->assertSame($expected, $scope->toArray());
 
-        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":1,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=1","first":"http:\/\/example.com\/books\/?page=1","next":"http:\/\/example.com\/books\/?page=2","last":"http:\/\/example.com\/books\/?page=5"}}';
+        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/1\/author-with-meta"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/2\/author-with-meta"}}}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":1,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=1","first":"http:\/\/example.com\/books\/?page=1","next":"http:\/\/example.com\/books\/?page=2","last":"http:\/\/example.com\/books\/?page=5"}}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -2305,6 +2389,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/1/co-author'
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/1/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/1/author-with-meta'
+                            ],
+                        ],
                     ],
                 ],
                 [
@@ -2330,6 +2420,12 @@ class JsonApiSerializerTest extends TestCase
                                 'related' => 'http://example.com/books/2/co-author'
                             ],
                         ],
+                        'author-with-meta' => [
+                            'links' => [
+                                'self' => 'http://example.com/books/2/relationships/author-with-meta',
+                                'related' => 'http://example.com/books/2/author-with-meta'
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -2352,7 +2448,7 @@ class JsonApiSerializerTest extends TestCase
 
         $this->assertSame($expected, $scope->toArray());
 
-        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}}}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":5,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=5","first":"http:\/\/example.com\/books\/?page=1","prev":"http:\/\/example.com\/books\/?page=4","last":"http:\/\/example.com\/books\/?page=5"}}';
+        $expectedJson = '{"data":[{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/1\/author-with-meta"}}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":1997},"links":{"self":"http:\/\/example.com\/books\/2"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author","related":"http:\/\/example.com\/books\/2\/author"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/co-author","related":"http:\/\/example.com\/books\/2\/co-author"}},"author-with-meta":{"links":{"self":"http:\/\/example.com\/books\/2\/relationships\/author-with-meta","related":"http:\/\/example.com\/books\/2\/author-with-meta"}}}}],"meta":{"pagination":{"total":10,"count":2,"per_page":2,"current_page":5,"total_pages":5}},"links":{"self":"http:\/\/example.com\/books\/?page=5","first":"http:\/\/example.com\/books\/?page=1","prev":"http:\/\/example.com\/books\/?page=4","last":"http:\/\/example.com\/books\/?page=5"}}';
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
@@ -2401,6 +2497,12 @@ class JsonApiSerializerTest extends TestCase
                         'links' => [
                             'self' => 'http://test.de/books/1/relationships/co-author',
                             'related' => 'http://test.de/books/1/co-author'
+                        ],
+                    ],
+                    'author-with-meta' => [
+                        'links' => [
+                            'self' => 'http://test.de/books/1/relationships/author-with-meta',
+                            'related' => 'http://test.de/books/1/author-with-meta'
                         ],
                     ],
                 ],
@@ -2453,6 +2555,12 @@ class JsonApiSerializerTest extends TestCase
                             'related' => 'http://test.de/books/1/co-author'
                         ],
                     ],
+                    'author-with-meta' => [
+                        'links' => [
+                            'self' => 'http://test.de/books/1/relationships/author-with-meta',
+                            'related' => 'http://test.de/books/1/author-with-meta'
+                        ],
+                    ],
                 ],
             ],
         ];
@@ -2492,7 +2600,27 @@ class JsonApiSerializerTest extends TestCase
                 ],
                 'links' => [
                     'self' => '/custom/link',
-                ]
+                ],
+                'relationships' => [
+                    'author' => [
+                        'links' => [
+                            'self' => 'http://test.de/books/1/relationships/author',
+                            'related' => 'http://test.de/books/1/author',
+                        ],
+                    ],
+                    'co-author' => [
+                        'links' => [
+                            'self' => 'http://test.de/books/1/relationships/co-author',
+                            'related' => 'http://test.de/books/1/co-author'
+                        ],
+                    ],
+                    'author-with-meta' => [
+                        'links' => [
+                            'self' => 'http://test.de/books/1/relationships/author-with-meta',
+                            'related' => 'http://test.de/books/1/author-with-meta'
+                        ],
+                    ],
+                ],
             ],
         ];
 


### PR DESCRIPTION
This PR changes the JsonApiSerializer to always add a 'relationships' key with links.  Before the serializer would only add links if the resource was included.

I had to update a lot of tests since the output changes.  This is a breaking change since new data is added to the output, but nothing is removed from the output so it shouldn't actually break any clients.

Closes #292 & #242.  Supersedes the changes in #272, so that PR should not be merged if this one is.

[Here is a link to the relevant part of the JSON:API specification](http://jsonapi.org/format/#document-resource-object-relationships).
