### PR TITLE
Change pagination links index to stdClass instead array

### DIFF
--- a/src/Serializer/ArraySerializer.php
+++ b/src/Serializer/ArraySerializer.php
@@ -102,14 +102,14 @@ class ArraySerializer extends SerializerAbstract
             'total_pages' => $lastPage,
         ];
 
-        $pagination['links'] = [];
+        $pagination['links'] = new \stdClass();
 
         if ($currentPage > 1) {
-            $pagination['links']['previous'] = $paginator->getUrl($currentPage - 1);
+            $pagination['links']->previous = $paginator->getUrl($currentPage - 1);
         }
 
         if ($currentPage < $lastPage) {
-            $pagination['links']['next'] = $paginator->getUrl($currentPage + 1);
+            $pagination['links']->next = $paginator->getUrl($currentPage + 1);
         }
 
         return ['pagination' => $pagination];


### PR DESCRIPTION
Hi all,

i change links pagination index because when transformer return data, if pagination is empty, meta -> links index is an array like this :

```
{
    meta : {
        links : []
    }
}
```

otherwise meta -> links is an object like this :

```
{
    meta : {
        links : {
            next : '',
            previous : ''
       }
    }
}
```

So in firts case is an empty array and is second case is an object.
With my patch in first case is an empty object.

P.S.: sorry for bad english =D  
