### PR TITLE
pulled duplicated code out into a private method

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -179,16 +179,7 @@ class JsonApiSerializer extends ArraySerializer
                 }
 
                 $includeObjects = $this->createIncludeObjects($includeObject);
-
-                foreach ($includeObjects as $object) {
-                    $includeType = $object['type'];
-                    $includeId = $object['id'];
-                    $cacheKey = "$includeType:$includeId";
-                    if (!array_key_exists($cacheKey, $linkedIds)) {
-                        $serializedData[] = $object;
-                        $linkedIds[$cacheKey] = $object;
-                    }
-                }
+                list($serializedData, $linkedIds) = $this->serializeIncludedObjectsWithCacheKey($includeObjects, $linkedIds, $serializedData);
             }
         }
 
@@ -389,16 +380,7 @@ class JsonApiSerializer extends ArraySerializer
         foreach ($data as $value) {
             foreach ($value as $includeObject) {
                 if (isset($includeObject['included'])) {
-                    foreach ($includeObject['included'] as $object) {
-                        $includeType = $object['type'];
-                        $includeId = $object['id'];
-                        $cacheKey = "$includeType:$includeId";
-
-                        if (!array_key_exists($cacheKey, $linkedIds)) {
-                            $includedData[] = $object;
-                            $linkedIds[$cacheKey] = $object;
-                        }
-                    }
+                    list($includedData, $linkedIds) = $this->serializeIncludedObjectsWithCacheKey($includeObject['included'], $linkedIds, $includedData);
                 }
             }
         }
@@ -571,5 +553,26 @@ class JsonApiSerializer extends ArraySerializer
         }
 
         return $relationship;
+    }
+
+    /**
+     * @param $includeObjects
+     * @param $linkedIds
+     * @param $serializedData
+     *
+     * @return array
+     */
+    private function serializeIncludedObjectsWithCacheKey($includeObjects, $linkedIds, $serializedData)
+    {
+        foreach ($includeObjects as $object) {
+            $includeType = $object['type'];
+            $includeId = $object['id'];
+            $cacheKey = "$includeType:$includeId";
+            if (!array_key_exists($cacheKey, $linkedIds)) {
+                $serializedData[] = $object;
+                $linkedIds[$cacheKey] = $object;
+            }
+        }
+        return [$serializedData, $linkedIds];
     }
 }


### PR DESCRIPTION
One of the things making this class difficult to maintain is that there is a lot of nested looping so it gets difficult to see what is actually happening.

I noticed that in Scrutinizer CI it was shouting about this in particular so I pulled it out into a method and returned it. I was tempted to pass the `$linkedIds` by reference as it is used by the loop and not returned, however I think that doing so would have made it more difficult to understand (Even though my implementation uses `list` to achieve a similar functionality)

There's also a question about masking the loops here, as from just reading the code you don't know that the method is going to loop through an array of data, although just reading through the code should be enough to do so. I could rename the method `loopThroughIncludedObjectsAndSerializeWithCacheKey` but that just seemed silly.