### PR TITLE
Use the pagination structure provided as is

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -266,7 +266,7 @@ class Scope
             }
 
             if (! empty($pagination)) {
-                $this->resource->setMetaValue(key($pagination), current($pagination));
+                $this->resource->setMeta($pagination);
             }
         }
 

--- a/test/Stub/Serializer/SerializerWithPaginationInRoot.php
+++ b/test/Stub/Serializer/SerializerWithPaginationInRoot.php
@@ -10,7 +10,7 @@ final class SerializerWithPaginationInRoot extends DataArraySerializer
     /**
      * {@inheritdoc}
      */
-    public function meta(array $meta): array
+    public function meta(array $meta)
     {
         return $meta;
     }

--- a/test/Stub/Serializer/SerializerWithPaginationInRoot.php
+++ b/test/Stub/Serializer/SerializerWithPaginationInRoot.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace League\Fractal\Test\Stub\Serializer;
+
+use League\Fractal\Pagination\PaginatorInterface;
+use League\Fractal\Serializer\DataArraySerializer;
+
+final class SerializerWithPaginationInRoot extends DataArraySerializer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function meta(array $meta): array
+    {
+        return $meta;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function paginator(PaginatorInterface $paginator)
+    {
+        return [
+            'total' => (int) $paginator->getTotal(),
+            'count' => (int) $paginator->getCount(),
+            'per_page' => (int) $paginator->getPerPage(),
+            'current_page' => (int) $paginator->getCurrentPage(),
+            'total_pages' => (int) $paginator->getLastPage(),
+        ];
+    }
+}


### PR DESCRIPTION
Fixes #341 

BC BREAK

The output of serializer is not being merged directly in the root, but instead it uses key() and current() to manipulate the output. Those functions return values for the internal array pointer. This means that if you, for example, provide an array with 5 elements as pagination output, only ONE of them will be merged to the root, which automatically force you to have a single element.

This also prevents the pagination links to be merged to the root links.

Example of `paginator()` return:

```php
return [
    'total' => 10,
    'count' => 5,
    'per_page' => 5,
    'current_page' => 1,
    'total_pages' => 2,
]
```
how it currently appears in the json (partial object):

```json
{"total": 10}
```

how it appears with the change (partial object):

```json
{"total": 10, "count":5, "per_page": 5, "current_page": 1, "total_pages": 2}
```

