### PR TITLE
Add $options parameter to toJson

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -287,11 +287,13 @@ class Scope
     /**
      * Convert the current data for this scope to JSON.
      *
+     * @param int $options
+     *
      * @return string
      */
-    public function toJson()
+    public function toJson($options = 0)
     {
-        return json_encode($this->toArray());
+        return json_encode($this->toArray(), $options);
     }
 
     /**

--- a/test/ScopeTest.php
+++ b/test/ScopeTest.php
@@ -89,6 +89,27 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $scope->toJson());
     }
+    
+    public function testToJsonWithOption()
+    {
+        $data = [
+            'foo' => 'bar',
+        ];
+
+        $manager = new Manager();
+
+        $resource = new Item($data, function ($data) {
+            return $data;
+        });
+
+        $scope = new Scope($manager, $resource);
+
+        $expected = json_encode([
+            'data' => $data,
+        ], JSON_PRETTY_PRINT);
+
+        $this->assertSame($expected, $scope->toJson(JSON_PRETTY_PRINT));
+    }
 
     public function testGetCurrentScope()
     {


### PR DESCRIPTION
Adds flexibility passing (optionally) an `$options` parameter to `toJson` method.

E.g. You could use this for debugging: `$this->fractal->createData($resource)->toJson(JSON_PRETTY_PRINT);`