### PR TITLE
[Feature] Add links of not included relationships

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -256,6 +256,10 @@ class Scope
                     $includedData,
                     $data
                 );
+
+                // If the serializer wants to inject additional information
+                // about the relationships, it can do so now.
+                $data = $serializer->injectRelationships($data, $this->resource);
             }
 
             $data = array_merge($data, $includedData);

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -34,7 +34,7 @@ class JsonApiSerializer extends ArraySerializer
     {
         $this->baseUrl = $baseUrl;
         $this->rootObjects = [];
-        $this->includeRelationshipsLinks = boolval($includeRelationshipsLinks);
+        $this->includeRelationshipsLinks = (bool) $includeRelationshipsLinks;
     }
 
     /**

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -116,6 +116,19 @@ abstract class SerializerAbstract
     }
 
     /**
+     * Hook for the serializer to inject custom relationship data.
+     *
+     * @param array $data
+     * @param ResourceInterface $resource
+     *
+     * @return array
+     */
+    public function injectRelationships($data, ResourceInterface $resource)
+    {
+        return $data;
+    }
+
+    /**
      * Hook for the serializer to modify the final list of includes.
      *
      * @param array             $includedData

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -2311,6 +2311,79 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    public function testSerializingItemResourceWithRelationshipsLinks()
+    {
+        $baseUrl = 'http://example.com';
+        $includeRelationshipsLinks = true;
+        $serializer = new JsonApiSerializer($baseUrl, $includeRelationshipsLinks);
+
+        $this->manager->setSerializer($serializer);
+        $this->manager->parseIncludes('author');
+
+        $bookData = [
+            'id' => 1,
+            'title' => 'Foo',
+            'year' => '1991',
+            '_author' => [
+                'id' => 1,
+                'name' => 'Dave',
+            ],
+        ];
+
+        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+
+        $scope = new Scope($this->manager, $resource);
+
+        $expected = [
+            'data' => [
+                'type' => 'books',
+                'id' => '1',
+                'attributes' => [
+                    'title' => 'Foo',
+                    'year' => 1991,
+                ],
+                'links' => [
+                    'self' => 'http://example.com/books/1',
+                ],
+                'relationships' => [
+                    'author' => [
+                        'links' => [
+                            "self" => "http://example.com/books/1/relationships/author",
+                            "related" => "http://example.com/books/1/author",
+                        ],
+                        'data' => [
+                            'type' => 'people',
+                            'id' => '1',
+                        ],
+                    ],
+                    'co-author' => [
+                        'links' => [
+                            "self" => "http://example.com/books/1/relationships/co-author",
+                            "related" => "http://example.com/books/1/co-author",
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
+                    'type' => 'people',
+                    'id' => '1',
+                    'attributes' => [
+                        'name' => 'Dave',
+                    ],
+                    'links' => [
+                        'self' => 'http://example.com/people/1',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $scope->toArray());
+
+        $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"links":{"self":"http:\/\/example.com\/books\/1"},"relationships":{"author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/author","related":"http:\/\/example.com\/books\/1\/author"},"data":{"type":"people","id":"1"}},"co-author":{"links":{"self":"http:\/\/example.com\/books\/1\/relationships\/co-author","related":"http:\/\/example.com\/books\/1\/co-author"}}}},"included":[{"type":"people","id":"1","attributes":{"name":"Dave"},"links":{"self":"http:\/\/example.com\/people\/1"}}]}';
+        $this->assertSame($expectedJson, $scope->toJson());
+    }
+
     public function tearDown()
     {
         Mockery::close();


### PR DESCRIPTION
This PR allows to create relationship links on the top level resource for all available includes. This allows to set all available relationship links without the need to include them.

Example:

```
{
  "links": {
    "self": "http://example.com/articles/1"
  },
  "data": {
    "type": "articles",
    "id": "1",
    "attributes": {
      "title": "JSON API paints my bikeshed!"
    },
    "relationships": {
      "author": {
        "links": {
          "related": "http://example.com/articles/1/author"
        }
      }
    }
  }
}
```

I've added a second parameter `$includeRelationshipsLinks` in `JsonApiSerializer::__construct()`. Default is set to `false` to keep BC. 
I'm not so happy about this second parameter. Maybe an options array would be better because it would allow more options for future configuration?

This PR should fix #367.

This refs also #331 but should not have any BC breaks.