### PR TITLE
[bugfix][JsonApiSerializer] Missing relations when item is referenced via multiple sources

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -588,11 +588,16 @@ class JsonApiSerializer extends ArraySerializer
                 $linkedIds[$cacheKey] = $object;
             } else {
                 // Merge any missing relationships that may have been requested from alternative instances of this include
-                if (isset($object['relationships'])) {
-                    foreach ($object['relationships'] as $relationName => $relation) {
-                        if (!isset($linkedIds[$cacheKey]['relationships'][$relationName])) {
-                            $serializedData[count($serializedData) - 1]['relationships'][$relationName] = $relation;
-                        }
+                if (array_key_exists($cacheKey, $linkedIds) && isset($object['relationships'])) {
+
+                    if (!isset($linkedIds[$cacheKey]['relationships'])){
+                        $linkedIds[$cacheKey]['relationships'] = [];
+                    }
+   
+                    if (array_diff_key($object['relationships'], $linkedIds[$cacheKey]['relationships'])) {
+                        $object['relationships'] = array_merge($object['relationships'], $linkedIds[$cacheKey]['relationships']); 
+                        $index = array_search($object, $serializedData);
+                        $serializedData[$index] = $linkedIds[$cacheKey] = $object;
                     }
                 }
             }

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -586,6 +586,15 @@ class JsonApiSerializer extends ArraySerializer
             if (!array_key_exists($cacheKey, $linkedIds)) {
                 $serializedData[] = $object;
                 $linkedIds[$cacheKey] = $object;
+            } else {
+                // Merge any missing relationships that may have been requested from alternative instances of this include
+                if (isset($object['relationships'])) {
+                    foreach ($object['relationships'] as $relationName => $relation) {
+                        if (!isset($linkedIds[$cacheKey]['relationships'][$relationName])) {
+                            $serializedData[count($serializedData) - 1]['relationships'][$relationName] = $relation;
+                        }
+                    }
+                }
             }
         }
         return [$serializedData, $linkedIds];

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -1596,6 +1596,108 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
         $scope->toArray();
     }
 
+    public function testSerializingItemResourceWithMultipleReferencesToSameInclude()
+    {
+        $this->manager->parseIncludes(['author.published.author']);
+
+        $bookData = [
+            'id' => 1,
+            'title' => 'Foo',
+            'year' => '1991',
+            '_author' => [
+                'id' => 1,
+                'name' => 'Dave',
+                '_published' => [
+                    [
+                        'id' => 1,
+                        'title' => 'Foo',
+                        'year' => '1991',
+                        '_author' => [
+                            'id' => 1,
+                            'name' => 'Dave',
+                        ]
+                    ],
+                    [
+                        'id' => 2,
+                        'title' => 'Bar',
+                        'year' => '2015',
+                        '_author' => [
+                            'id' => 1,
+                            'name' => 'Dave',
+                        ]
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+
+        $scope = new Scope($this->manager, $resource);
+
+        $expected = [
+            'data' => [
+                'type' => 'books',
+                'id' => '1',
+                'attributes' => [
+                    'title' => 'Foo',
+                    'year' => 1991,
+                ],
+                'relationships' => [
+                    'author' => [
+                        'data' => [
+                            'type' => 'people',
+                            'id' => '1',
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
+                    'type' => 'people',
+                    'id' => '1',
+                    'attributes' => [
+                        'name' => 'Dave',
+                    ],
+                    'relationships' => [
+                        'published' => [
+                            'data' => [
+                                [
+                                    'type' => 'books',
+                                    'id' => '1',
+                                ],
+                                [
+                                    'type' => 'books',
+                                    'id' => '2',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'books',
+                    'id' => '2',
+                    'attributes' => [
+                        'title' => 'Bar',
+                        'year' => 2015,
+                    ],
+                    'relationships' => [
+                        'author' => [
+                            'data' => [
+                                'type' => 'people',
+                                'id' => '1',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $scope->toArray());
+
+        $expectedJson = '{"data":{"type":"books","id":"1","attributes":{"title":"Foo","year":1991},"relationships":{"author":{"data":{"type":"people","id":"1"}}}},"included":[{"type":"people","id":"1","attributes":{"name":"Dave"},"relationships":{"published":{"data":[{"type":"books","id":"1"},{"type":"books","id":"2"}]}}},{"type":"books","id":"2","attributes":{"title":"Bar","year":2015},"relationships":{"author":{"data":{"type":"people","id":"1"}}}}]}';
+        $this->assertSame($expectedJson, $scope->toJson());
+    }
+
     public function testSerializingItemWithReferenceToRootObject()
     {
         $this->manager->parseIncludes('published.author');


### PR DESCRIPTION
Hello,

I encountered this bug today and thought i may as well attempt a fix. I think this issue explains it pretty well: https://github.com/thephpleague/fractal/issues/337

Effectively if the same item is included from more than one place, only the first one will have its requested relation's. This PR just adds an additional check to ensure that the existing copy of the include has any other includes (found on the later versions) applied on it as well.

Happy to make any changes to better fit the library.

Thanks,
Carl