### PR TITLE
JsonApiSerializer get type from transformer instead of $resoruceKey

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -61,16 +61,18 @@ class JsonApiSerializer extends ArraySerializer
     public function item($resourceKey, array $data)
     {
         $id = $this->getIdFromData($data);
+        $type = $this->getTypeFromData($data);
 
         $resource = [
             'data' => [
-                'type' => $resourceKey,
+                'type' => "$type",
                 'id' => "$id",
                 'attributes' => $data,
             ],
         ];
 
         unset($resource['data']['attributes']['id']);
+        unset($resource['data']['attributes']['type']);
 
         if(isset($resource['data']['attributes']['links'])) {
             $custom_links = $data['links'];
@@ -84,7 +86,7 @@ class JsonApiSerializer extends ArraySerializer
 
         if ($this->shouldIncludeLinks()) {
             $resource['data']['links'] = [
-                'self' => "{$this->baseUrl}/$resourceKey/$id",
+                'self' => "{$this->baseUrl}/$type/$id",
             ];
             if(isset($custom_links)) {
                 $resource['data']['links'] = array_merge($custom_links, $resource['data']['links']);
@@ -255,7 +257,7 @@ class JsonApiSerializer extends ArraySerializer
      */
     public function getMandatoryFields()
     {
-        return ['id'];
+        return ['id', 'type'];
     }
 
     /**
@@ -378,6 +380,21 @@ class JsonApiSerializer extends ArraySerializer
             );
         }
         return $data['id'];
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return string
+     */
+    protected function getTypeFromData(array $data)
+    {
+        if (!array_key_exists('type', $data)) {
+            throw new InvalidArgumentException(
+                'JSON API resource objects MUST have a valid type'
+            );
+        }
+        return $data['type'];
     }
 
     /**

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -47,7 +47,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
+        $resource = new Collection($booksData, new JsonApiBookTransformer());
         $scope = new Scope($this->manager, $resource);
 
         $expected = [
@@ -97,7 +97,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -153,7 +153,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -202,7 +202,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             '_author' => null,
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -249,7 +249,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($authorData, new JsonApiAuthorTransformer(), 'people');
+        $resource = new Item($authorData, new JsonApiAuthorTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -311,7 +311,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             '_published' => [],
         ];
 
-        $resource = new Item($authorData, new JsonApiAuthorTransformer(), 'people');
+        $resource = new Item($authorData, new JsonApiAuthorTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -348,7 +348,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -381,7 +381,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer());
         $resource->setMetaValue('foo', 'bar');
 
         $scope = new Scope($this->manager, $resource);
@@ -421,7 +421,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ]
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer());
         $resource->setMetaValue('foo', 'bar');
 
         $scope = new Scope($this->manager, $resource);
@@ -472,7 +472,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
+        $resource = new Collection($booksData, new JsonApiBookTransformer());
         $scope = new Scope($this->manager, $resource);
 
         $expected = [
@@ -527,7 +527,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
+        $resource = new Collection($booksData, new JsonApiBookTransformer());
         $scope = new Scope($this->manager, $resource);
 
         $expected = [
@@ -611,7 +611,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
+        $resource = new Collection($booksData, new JsonApiBookTransformer());
         $scope = new Scope($this->manager, $resource);
 
         $expected = [
@@ -702,7 +702,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($authorsData, new JsonApiAuthorTransformer(), 'people');
+        $resource = new Collection($authorsData, new JsonApiAuthorTransformer());
         $scope = new Scope($this->manager, $resource);
 
         $expected = [
@@ -815,7 +815,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($authorsData, new JsonApiAuthorTransformer(), 'people');
+        $resource = new Collection($authorsData, new JsonApiAuthorTransformer());
         $scope = new Scope($this->manager, $resource);
 
         $expected = [
@@ -889,7 +889,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
+        $resource = new Collection($booksData, new JsonApiBookTransformer());
         $resource->setMetaValue('foo', 'bar');
 
         $scope = new Scope($this->manager, $resource);
@@ -949,7 +949,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
+        $resource = new Collection($booksData, new JsonApiBookTransformer());
         $scope = new Scope($this->manager, $resource);
 
         $expected = [
@@ -1030,7 +1030,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -1105,7 +1105,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -1155,7 +1155,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
+        $resource = new Collection($booksData, new JsonApiBookTransformer());
         $scope = new Scope($this->manager, $resource);
 
         $expected = [
@@ -1207,7 +1207,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -1278,7 +1278,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($authorData, new JsonApiAuthorTransformer(), 'people');
+        $resource = new Item($authorData, new JsonApiAuthorTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -1370,7 +1370,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Collection($bookData, new JsonApiBookTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -1484,7 +1484,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($authorData, new JsonApiAuthorTransformer(), 'people');
+        $resource = new Collection($authorData, new JsonApiAuthorTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -1590,7 +1590,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             'year' => '1991',
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer());
 
         $scope = new Scope($this->manager, $resource);
         $scope->toArray();
@@ -1619,7 +1619,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($authorData, new JsonApiAuthorTransformer(), 'people');
+        $resource = new Item($authorData, new JsonApiAuthorTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -1723,7 +1723,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
+        $resource = new Collection($booksData, new JsonApiBookTransformer());
 
         $scope = new Scope($this->manager, $resource);
 
@@ -1835,7 +1835,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
+        $resource = new Collection($booksData, new JsonApiBookTransformer());
         $resource->setPaginator($paginator);
         $scope = new Scope($this->manager, $resource);
 
@@ -1934,7 +1934,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
+        $resource = new Collection($booksData, new JsonApiBookTransformer());
         $resource->setPaginator($paginator);
         $scope = new Scope($this->manager, $resource);
 
@@ -2032,7 +2032,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Collection($booksData, new JsonApiBookTransformer(), 'books');
+        $resource = new Collection($booksData, new JsonApiBookTransformer());
         $resource->setPaginator($paginator);
         $scope = new Scope($this->manager, $resource);
 
@@ -2102,7 +2102,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer('test.de'), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer('test.de'));
 
         $scope = new Scope($manager, $resource);
 
@@ -2139,7 +2139,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer());
 
         $scope = new Scope($manager, $resource);
 
@@ -2189,7 +2189,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $resource = new Item($bookData, new JsonApiBookTransformer(), 'books');
+        $resource = new Item($bookData, new JsonApiBookTransformer());
 
         $scope = new Scope($this->manager, $resource);
 

--- a/test/Stub/Transformer/JsonApiAuthorTransformer.php
+++ b/test/Stub/Transformer/JsonApiAuthorTransformer.php
@@ -10,6 +10,7 @@ class JsonApiAuthorTransformer extends TransformerAbstract
 
     public function transform(array $author)
     {
+        $author['type'] = 'people';
         unset($author['_published']);
 
         return $author;
@@ -23,8 +24,7 @@ class JsonApiAuthorTransformer extends TransformerAbstract
 
         return $this->collection(
             $author['_published'],
-            new JsonApiBookTransformer(),
-            'books'
+            new JsonApiBookTransformer()
         );
     }
 }

--- a/test/Stub/Transformer/JsonApiBookTransformer.php
+++ b/test/Stub/Transformer/JsonApiBookTransformer.php
@@ -11,6 +11,7 @@ class JsonApiBookTransformer extends TransformerAbstract
 
     public function transform(array $book)
     {
+        $book['type'] = 'books';
         $book['year'] = (int) $book['year'];
         unset($book['_author']);
         unset($book['_co_author']);
@@ -28,7 +29,7 @@ class JsonApiBookTransformer extends TransformerAbstract
             return $this->null();
         }
 
-        return $this->item($book['_author'], new JsonApiAuthorTransformer(), 'people');
+        return $this->item($book['_author'], new JsonApiAuthorTransformer());
     }
 
     public function includeCoAuthor(array $book)
@@ -41,6 +42,6 @@ class JsonApiBookTransformer extends TransformerAbstract
             return $this->null();
         }
 
-        return $this->item($book['_co_author'], new JsonApiAuthorTransformer(), 'people');
+        return $this->item($book['_co_author'], new JsonApiAuthorTransformer());
     }
 }


### PR DESCRIPTION
This is not an insignificant change, so I understand it may have to wait for 1.0 to be merged in. But I thought it was important enough to take a stab at and at least have a discussion about. Maybe there are some way around the breaks that I haven't thought of quite yet. 

The are actually two issues here but they're functionally inseparable. 

 1. The resourceKey represents the top level member of a Fractal response, for a JSON API Resource, this will always be `data` (and sometimes an injected `links`, `included` and `meta`). [source](http://jsonapi.org/format/#document-top-level)
    
    _(NOTE that the current JsonApiSerializer could be renamed JsonApiResourceSerializer and a future JsonApiErrorSerializer could theoretically exist that would serialize the data differently and use `errors` as its resourceKey)_

 2. Per the JSON API standard `id` and `type` are reserved words and cannot be used as attributes [source](http://jsonapi.org/format/#document-resource-object-fields)

So this PR aims to pull the `type` from the transformed data and strips it from the attributes (similarly to the way the `id` is handled). At the same time, it ignores any provided resourceKey since they keys are well defined by the JSON API specification. 

BREAKING: While technically serializing type as an attribute is a bug, the previous implementation gave no warning or error if type was included. After this the type will be striped out of attributes.

BREAKING: `type` is now a required element returned from the transformer (similar to id). (This could be mitigated by using $resourceKey as a default if no 'type' is provided)

BREAKING: The $resourceKey will be ignored now, and the type used for serializing.

EDIT: I suppose I could get around the breaking changes by doing exactly as my note pointed out and instead of "fixing" JsonApiSerializer, break it out into a new JsonApiResourceSerializer.