### PR TITLE
Fix: Class name does not match project structure

### DIFF
--- a/test/Resource/CollectionTest.php
+++ b/test/Resource/CollectionTest.php
@@ -1,4 +1,4 @@
-<?php namespace League\Fractal\Test;
+<?php namespace League\Fractal\Test\Resource;
 
 use League\Fractal\Pagination\Cursor;
 use League\Fractal\Resource\Collection;

--- a/test/Resource/ItemTest.php
+++ b/test/Resource/ItemTest.php
@@ -1,4 +1,4 @@
-<?php namespace League\Fractal\Test;
+<?php namespace League\Fractal\Test\Resource;
 
 use League\Fractal\Resource\Item;
 use Mockery;

--- a/test/Serializer/ArraySerializerTest.php
+++ b/test/Serializer/ArraySerializerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace League\Fractal\Test\Serializer;
 
 use League\Fractal\Manager;
 use League\Fractal\Resource\Collection;
@@ -7,8 +7,9 @@ use League\Fractal\Resource\NullResource;
 use League\Fractal\Scope;
 use League\Fractal\Serializer\ArraySerializer;
 use League\Fractal\Test\Stub\Transformer\GenericBookTransformer;
+use Mockery;
 
-class ArraySerializerTest extends PHPUnit_Framework_TestCase
+class ArraySerializerTest extends \PHPUnit_Framework_TestCase
 {
     private $bookItemInput = [
         'title' => 'Foo',

--- a/test/Serializer/DataArraySerializerTest.php
+++ b/test/Serializer/DataArraySerializerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace League\Fractal\Test\Resource;
 
 use League\Fractal\Manager;
 use League\Fractal\Resource\Collection;
@@ -7,8 +7,9 @@ use League\Fractal\Resource\NullResource;
 use League\Fractal\Scope;
 use League\Fractal\Serializer\DataArraySerializer;
 use League\Fractal\Test\Stub\Transformer\GenericBookTransformer;
+use Mockery;
 
-class DataArraySerializerTest extends PHPUnit_Framework_TestCase
+class DataArraySerializerTest extends \PHPUnit_Framework_TestCase
 {
     public function testSerializingItemResource()
     {

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace League\Fractal\Test\Serializer;
 
 use League\Fractal\Manager;
 use League\Fractal\Resource\Collection;
@@ -7,8 +7,9 @@ use League\Fractal\Scope;
 use League\Fractal\Serializer\JsonApiSerializer;
 use League\Fractal\Test\Stub\Transformer\JsonApiAuthorTransformer;
 use League\Fractal\Test\Stub\Transformer\JsonApiBookTransformer;
+use Mockery;
 
-class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
+class JsonApiSerializerTest extends \PHPUnit_Framework_TestCase
 {
     private $manager;
 


### PR DESCRIPTION
This PR

* [x] fixes tests which namespace doesn't match the project structure