### PR TITLE
Fix: Reference classes in annotations relative to root namespace

### DIFF
--- a/test/ManagerTest.php
+++ b/test/ManagerTest.php
@@ -17,7 +17,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The parseIncludes() method expects a string or an array. NULL given
      */
     public function testInvalidParseInclude()
@@ -28,7 +28,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The parseIncludes() method expects a string or an array. integer given
      */
     public function testIceTParseInclude()
@@ -84,7 +84,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The parseExcludes() method expects a string or an array. NULL given
      */
     public function testInvalidParseExclude()
@@ -95,7 +95,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The parseExcludes() method expects a string or an array. integer given
      */
     public function testIceTParseExclude()

--- a/test/ParamBagTest.php
+++ b/test/ParamBagTest.php
@@ -32,7 +32,7 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException \LogicException
      * @expectedExceptionMessage Modifying parameters is not permitted
      */
     public function testArrayAccessSetFails()
@@ -43,7 +43,7 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException \LogicException
      * @expectedExceptionMessage Modifying parameters is not permitted
      */
     public function testArrayAccessUnsetFails()
@@ -64,7 +64,7 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException \LogicException
      * @expectedExceptionMessage Modifying parameters is not permitted
      */
     public function testObjectAccessSetFails()
@@ -75,7 +75,7 @@ class ParamBagTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException \LogicException
      * @expectedExceptionMessage Modifying parameters is not permitted
      */
     public function testObjectAccessUnsetFails()

--- a/test/Resource/CollectionTest.php
+++ b/test/Resource/CollectionTest.php
@@ -21,7 +21,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Resource\Collection::setData
+     * @covers \League\Fractal\Resource\Collection::setData
      */
     public function testSetData()
     {
@@ -41,7 +41,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Resource\Collection::setTransformer
+     * @covers \League\Fractal\Resource\Collection::setTransformer
      */
     public function testSetTransformer()
     {
@@ -51,7 +51,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Resource\Collection::setCursor
+     * @covers \League\Fractal\Resource\Collection::setCursor
      */
     public function testSetCursor()
     {
@@ -61,7 +61,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Resource\Collection::getCursor
+     * @covers \League\Fractal\Resource\Collection::getCursor
      */
     public function testGetCursor()
     {
@@ -72,8 +72,8 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Resource\Collection::setPaginator
-     * @covers League\Fractal\Resource\Collection::getPaginator
+     * @covers \League\Fractal\Resource\Collection::setPaginator
+     * @covers \League\Fractal\Resource\Collection::getPaginator
      */
     public function testGetSetPaginator()
     {
@@ -84,8 +84,8 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Resource\Collection::setMetaValue
-     * @covers League\Fractal\Resource\Collection::getMetaValue
+     * @covers \League\Fractal\Resource\Collection::setMetaValue
+     * @covers \League\Fractal\Resource\Collection::getMetaValue
      */
     public function testGetSetMeta()
     {
@@ -99,7 +99,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Resource\Collection::setResourceKey
+     * @covers \League\Fractal\Resource\Collection::setResourceKey
      */
     public function testSetResourceKey()
     {
@@ -108,7 +108,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Resource\Collection::getResourceKey
+     * @covers \League\Fractal\Resource\Collection::getResourceKey
      */
     public function testGetResourceKey()
     {

--- a/test/Resource/ItemTest.php
+++ b/test/Resource/ItemTest.php
@@ -27,7 +27,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Resource\Item::setResourceKey
+     * @covers \League\Fractal\Resource\Item::setResourceKey
      */
     public function testSetResourceKey()
     {
@@ -37,7 +37,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Resource\Item::getResourceKey
+     * @covers \League\Fractal\Resource\Item::getResourceKey
      */
     public function testGetResourceKey()
     {

--- a/test/ScopeTest.php
+++ b/test/ScopeTest.php
@@ -89,7 +89,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $scope->toJson());
     }
-    
+
     public function testToJsonWithOption()
     {
         $data = [
@@ -203,7 +203,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testScopeRequiresConcreteImplementation()
     {
@@ -324,7 +324,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers \League\Fractal\Scope::executeResourceTransformers
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Argument $resource should be an instance of League\Fractal\Resource\Item or League\Fractal\Resource\Collection
      */
     public function testCreateDataWithClassFuckKnows()
@@ -487,7 +487,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Scope::toArray
+     * @covers \League\Fractal\Scope::toArray
      * @dataProvider fieldsetsProvider
      */
     public function testToArrayWithFieldsets($fieldsetsToParse, $expected)
@@ -527,7 +527,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Scope::toArray
+     * @covers \League\Fractal\Scope::toArray
      * @dataProvider fieldsetsWithMandatorySerializerFieldsProvider
      */
     public function testToArrayWithFieldsetsAndMandatorySerializerFields($fieldsetsToParse, $expected)
@@ -605,7 +605,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\Scope::toArray
+     * @covers \League\Fractal\Scope::toArray
      * @dataProvider fieldsetsWithSideLoadIncludesProvider
      */
     public function testToArrayWithSideloadedIncludesAndFieldsets($fieldsetsToParse, $expected)

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -1580,7 +1580,7 @@ class JsonApiSerializerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage JSON API resource objects MUST have a valid id
      */
     public function testExceptionThrownIfResourceHasNoId()

--- a/test/TransformerAbstractTest.php
+++ b/test/TransformerAbstractTest.php
@@ -9,7 +9,7 @@ use Mockery as m;
 class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @covers League\Fractal\TransformerAbstract::setAvailableIncludes
+     * @covers \League\Fractal\TransformerAbstract::setAvailableIncludes
      */
     public function testSetAvailableIncludes()
     {
@@ -18,7 +18,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::getAvailableIncludes
+     * @covers \League\Fractal\TransformerAbstract::getAvailableIncludes
      */
     public function testGetAvailableIncludes()
     {
@@ -29,7 +29,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::setDefaultIncludes
+     * @covers \League\Fractal\TransformerAbstract::setDefaultIncludes
      */
     public function testSetDefaultIncludes()
     {
@@ -38,7 +38,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::getDefaultIncludes
+     * @covers \League\Fractal\TransformerAbstract::getDefaultIncludes
      */
     public function testGetDefaultIncludes()
     {
@@ -49,7 +49,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::setCurrentScope
+     * @covers \League\Fractal\TransformerAbstract::setCurrentScope
      */
     public function testSetCurrentScope()
     {
@@ -60,7 +60,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::getCurrentScope
+     * @covers \League\Fractal\TransformerAbstract::getCurrentScope
      */
     public function testGetCurrentScope()
     {
@@ -94,9 +94,9 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::processIncludedResources
-     * @covers League\Fractal\TransformerAbstract::callIncludeMethod
-     * @expectedException BadMethodCallException
+     * @covers \League\Fractal\TransformerAbstract::processIncludedResources
+     * @covers \League\Fractal\TransformerAbstract::callIncludeMethod
+     * @expectedException \BadMethodCallException
      */
     public function testProcessEmbeddedResourcesInvalidAvailableEmbed()
     {
@@ -113,9 +113,9 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::processIncludedResources
-     * @covers League\Fractal\TransformerAbstract::callIncludeMethod
-     * @expectedException BadMethodCallException
+     * @covers \League\Fractal\TransformerAbstract::processIncludedResources
+     * @covers \League\Fractal\TransformerAbstract::callIncludeMethod
+     * @expectedException \BadMethodCallException
      */
     public function testProcessEmbeddedResourcesInvalidDefaultEmbed()
     {
@@ -130,8 +130,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::processIncludedResources
-     * @covers League\Fractal\TransformerAbstract::callIncludeMethod
+     * @covers \League\Fractal\TransformerAbstract::processIncludedResources
+     * @covers \League\Fractal\TransformerAbstract::callIncludeMethod
      */
     public function testProcessIncludedAvailableResources()
     {
@@ -152,8 +152,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::processIncludedResources
-     * @covers League\Fractal\TransformerAbstract::figureOutWhichIncludes
+     * @covers \League\Fractal\TransformerAbstract::processIncludedResources
+     * @covers \League\Fractal\TransformerAbstract::figureOutWhichIncludes
      */
     public function testProcessExcludedAvailableResources()
     {
@@ -180,8 +180,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::processIncludedResources
-     * @covers League\Fractal\TransformerAbstract::figureOutWhichIncludes
+     * @covers \League\Fractal\TransformerAbstract::processIncludedResources
+     * @covers \League\Fractal\TransformerAbstract::figureOutWhichIncludes
      */
     public function testProcessExcludedDefaultResources()
     {
@@ -207,8 +207,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::processIncludedResources
-     * @covers League\Fractal\TransformerAbstract::callIncludeMethod
+     * @covers \League\Fractal\TransformerAbstract::processIncludedResources
+     * @covers \League\Fractal\TransformerAbstract::callIncludeMethod
      */
     public function testProcessIncludedAvailableResourcesEmptyEmbed()
     {
@@ -226,8 +226,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::callIncludeMethod
-     * @expectedException Exception
+     * @covers \League\Fractal\TransformerAbstract::callIncludeMethod
+     * @expectedException \Exception
      * @expectedExceptionMessage Invalid return value from League\Fractal\TransformerAbstract::includeBook().
      */
     public function testCallEmbedMethodReturnsCrap()
@@ -244,8 +244,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::processIncludedResources
-     * @covers League\Fractal\TransformerAbstract::callIncludeMethod
+     * @covers \League\Fractal\TransformerAbstract::processIncludedResources
+     * @covers \League\Fractal\TransformerAbstract::callIncludeMethod
      */
     public function testProcessEmbeddedDefaultResources()
     {
@@ -265,8 +265,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::processIncludedResources
-     * @covers League\Fractal\TransformerAbstract::callIncludeMethod
+     * @covers \League\Fractal\TransformerAbstract::processIncludedResources
+     * @covers \League\Fractal\TransformerAbstract::callIncludeMethod
      */
     public function testIncludedItem()
     {
@@ -303,8 +303,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::processIncludedResources
-     * @covers League\Fractal\TransformerAbstract::callIncludeMethod
+     * @covers \League\Fractal\TransformerAbstract::processIncludedResources
+     * @covers \League\Fractal\TransformerAbstract::callIncludeMethod
      */
     public function testIncludedCollection()
     {
@@ -330,8 +330,8 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::processIncludedResources
-     * @covers League\Fractal\TransformerAbstract::callIncludeMethod
+     * @covers \League\Fractal\TransformerAbstract::processIncludedResources
+     * @covers \League\Fractal\TransformerAbstract::callIncludeMethod
      */
     public function testProcessEmbeddedDefaultResourcesEmptyEmbed()
     {
@@ -346,7 +346,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::item
+     * @covers \League\Fractal\TransformerAbstract::item
      */
     public function testItem()
     {
@@ -357,7 +357,7 @@ class TransformerAbstractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers League\Fractal\TransformerAbstract::collection
+     * @covers \League\Fractal\TransformerAbstract::collection
      */
     public function testCollection()
     {


### PR DESCRIPTION
This PR

* [x] references classes used in test annotations relative to the root namespace

🤷‍♂️ PhpStorm complains otherwise.