### PR TITLE
[Feature] Add 'Primitive' Resource

### DIFF
--- a/src/Resource/Primitive.php
+++ b/src/Resource/Primitive.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the League\Fractal package.
+ *
+ * (c) Phil Sturgeon <me@philsturgeon.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\Fractal\Resource;
+
+/**
+ * Primitive Resource
+ *
+ * The Primitive Resource can store any primitive data, like a string, integer,
+ * float, double etc.
+ */
+class Primitive extends ResourceAbstract
+{
+    //
+}

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -14,6 +14,7 @@ namespace League\Fractal;
 use InvalidArgumentException;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
+use League\Fractal\Resource\Primitive;
 use League\Fractal\Resource\NullResource;
 use League\Fractal\Resource\ResourceInterface;
 use League\Fractal\Serializer\SerializerAbstract;
@@ -297,6 +298,38 @@ class Scope
     public function toJson($options = 0)
     {
         return json_encode($this->toArray(), $options);
+    }
+
+    /**
+     * Transformer a primitive resource
+     *
+     * @return mixed
+     */
+    public function transformPrimitiveResource()
+    {
+        if (! ($this->resource instanceof Primitive)) {
+            throw new InvalidArgumentException(
+                'Argument $resource should be an instance of League\Fractal\Resource\Primitive'
+            );
+        }
+
+        $transformer = $this->resource->getTransformer();
+        $data = $this->resource->getData();
+
+        if (null == $transformer) {
+            $transformer = function ($input) {
+                return $input;
+            };
+        }
+
+        if (is_callable($transformer)) {
+            $transformedData = call_user_func($transformer, $data);
+        } else {
+            $transformer->setCurrentScope($this);
+            $transformedData = $transformer->transform($data);
+        }
+
+        return $transformedData;
     }
 
     /**

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -316,13 +316,9 @@ class Scope
         $transformer = $this->resource->getTransformer();
         $data = $this->resource->getData();
 
-        if (null == $transformer) {
-            $transformer = function ($input) {
-                return $input;
-            };
-        }
-
-        if (is_callable($transformer)) {
+        if (null === $transformer) {
+            $transformedData = $data;
+        } elseif (is_callable($transformer)) {
             $transformedData = call_user_func($transformer, $data);
         } else {
             $transformer->setCurrentScope($this);

--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -14,6 +14,7 @@ namespace League\Fractal;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
 use League\Fractal\Resource\NullResource;
+use League\Fractal\Resource\Primitive;
 use League\Fractal\Resource\ResourceInterface;
 
 /**
@@ -155,7 +156,11 @@ abstract class TransformerAbstract
         if ($resource = $this->callIncludeMethod($scope, $include, $data)) {
             $childScope = $scope->embedChildScope($include, $resource);
 
-            $includedData[$include] = $childScope->toArray();
+            if ($childScope->getResource() instanceof Primitive) {
+                $includedData[$include] = $childScope->transformPrimitiveResource();
+            } else {
+                $includedData[$include] = $childScope->toArray();
+            }
         }
 
         return $includedData;
@@ -241,6 +246,20 @@ abstract class TransformerAbstract
         $this->currentScope = $currentScope;
 
         return $this;
+    }
+
+    /**
+     * Create a new primitive resource object.
+     *
+     * @param mixed                        $data
+     * @param callable|null                $transformer
+     * @param string                       $resourceKey
+     *
+     * @return Primitive
+     */
+    protected function primitive($data, $transformer = null, $resourceKey = null)
+    {
+        return new Primitive($data, $transformer, $resourceKey);
     }
 
     /**

--- a/test/Resource/PrimitiveTest.php
+++ b/test/Resource/PrimitiveTest.php
@@ -1,0 +1,49 @@
+<?php namespace League\Fractal\Test\Resource;
+
+use League\Fractal\Resource\Primitive;
+use Mockery;
+
+class PrimitiveTest extends \PHPUnit_Framework_TestCase
+{
+    protected $simplePrimitive = 'sample string';
+
+    public function testGetData()
+    {
+        $primitive = new Primitive($this->simplePrimitive);
+
+        $this->assertSame($primitive->getData(), $this->simplePrimitive);
+    }
+
+    public function testGetTransformer()
+    {
+        $primitive = new Primitive($this->simplePrimitive, function () {});
+
+        $this->assertTrue(is_callable($primitive->getTransformer()));
+
+        $transformer = 'thismightbeacallablestring';
+        $primitive = new Primitive($this->simplePrimitive, $transformer);
+
+        $this->assertSame($primitive->getTransformer(), $transformer);
+    }
+
+    /**
+     * @covers \League\Fractal\Resource\Primitive::setResourceKey
+     */
+    public function testSetResourceKey()
+    {
+        $primitive = Mockery::mock('League\Fractal\Resource\Primitive')->makePartial();
+
+        $this->assertSame($primitive, $primitive->setResourceKey('foo'));
+    }
+
+    /**
+     * @covers \League\Fractal\Resource\Primitive::getResourceKey
+     */
+    public function testGetResourceKey()
+    {
+        $primitive = Mockery::mock('League\Fractal\Resource\Primitive')->makePartial();
+        $primitive->setResourceKey('foo');
+
+        $this->assertSame('foo', $primitive->getResourceKey());
+    }
+}

--- a/test/Stub/Transformer/PrimitiveIncludeBookTransformer.php
+++ b/test/Stub/Transformer/PrimitiveIncludeBookTransformer.php
@@ -1,0 +1,20 @@
+<?php namespace League\Fractal\Test\Stub\Transformer;
+
+use League\Fractal\TransformerAbstract;
+
+class PrimitiveIncludeBookTransformer extends TransformerAbstract
+{
+    protected $defaultIncludes = [
+        'price'
+    ];
+
+    public function transform()
+    {
+        return ['a' => 'b'];
+    }
+
+    public function includePrice(array $book)
+    {
+        return $this->primitive($book['price'], function ($price) {return (int) $price;});
+    }
+}


### PR DESCRIPTION
Added `Primitive` resource type, allows to use primitives (strings, ints, floats) to be included, just like arrays.

This will allow to optionally include primitive fields in the transformed data. Currently, only `Item`s and `Collection`s can be included in the transformed data.

Example : 
```php
<?php 
use Book;

class MyTransformer extends TransformerAbstract
{
    $availableIncludes = ['price'];
    public function includePrice(Book $book)
    {
        return $this->primitive($book->price, function ($price) {
            return $price + 40; // This can get complex
        });
    }
}
?>
```
