### PR TITLE
Added type hint. Might break unintented usage.

### DIFF
--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -241,7 +241,7 @@ abstract class TransformerAbstract
      *
      * @return $this
      */
-    public function setCurrentScope($currentScope)
+    public function setCurrentScope(Scope $currentScope)
     {
         $this->currentScope = $currentScope;
 


### PR DESCRIPTION
Warning: might break unintented usage of `setCurrentScope` with a non Scope typed object.