### PR TITLE
fix mixed content errors over https

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,20 +15,20 @@
     {% if site.data.images.favicon %}
         <link rel="icon" type="image/x-icon" href="{{ site.data.images.favicon }}" />
     {% else %}
-        <link rel="icon" type="image/x-icon" href="http://theme.thephpleague.com/img/favicon.ico" />
+        <link rel="icon" type="image/x-icon" href="https://theme.thephpleague.com/img/favicon.ico" />
     {% endif %}
     {% if site.data.images.apple_touch %}
         <link rel="apple-touch-icon-precomposed" href="{{ site.data.images.apple_touch }}">
     {% else %}
-        <link rel="apple-touch-icon-precomposed" href="http://theme.thephpleague.com/img/apple-touch-icon-precomposed.png">
+        <link rel="apple-touch-icon-precomposed" href="https://theme.thephpleague.com/img/apple-touch-icon-precomposed.png">
     {% endif %}
-    <link rel="stylesheet" href="http://theme.thephpleague.com/css/all.css">
+    <link rel="stylesheet" href="https://theme.thephpleague.com/css/all.css">
 </head>
 <body>
 
 <section class="all_packages">
-    <a href="http://thephpleague.com/">
-        <img src="http://theme.thephpleague.com/img/loep_logo.png" width="195" height="200" alt="The League of Extraordinary Packages">
+    <a href="https://thephpleague.com/">
+        <img src="https://theme.thephpleague.com/img/loep_logo.png" width="195" height="200" alt="The League of Extraordinary Packages">
     </a>
     <h2>Our Packages:</h2>
     <ul>
@@ -46,7 +46,7 @@
         <span class="name">{{ site.data.project.title }}</span>
         <span class="tagline">{{ site.data.project.tagline }}</span>
     </a>
-    <a href="http://thephpleague.com/" class="league">
+    <a href="https://thephpleague.com/" class="league">
         Presented by The League of Extraordinary Packages
     </a>
 </header>
@@ -64,7 +64,7 @@
             <ul>
                 {% for link in section[1] %}
                     <li {% if page.url == link[1] %}class="selected"{% endif %}>
-                        <a href="http://fractal.thephpleague.com{{ link[1] }}">{{ link[0] }}</a>
+                        <a href="https://fractal.thephpleague.com{{ link[1] }}">{{ link[0] }}</a>
                     </li>
                 {% endfor %}
             </ul>
@@ -76,13 +76,13 @@
 </main>
 
 <footer>
-    <span>&copy; Copyright <a href="http://thephpleague.com">The League of Extraordinary Packages</a>.</span>
-    <span>Site design by <a href="http://reinink.ca">Jonathan Reinink</a>.</span>
+    <span>&copy; Copyright <a href="https://thephpleague.com">The League of Extraordinary Packages</a>.</span>
+    <span>Site design by <a href="https://reinink.ca">Jonathan Reinink</a>.</span>
 </footer>
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-<script src="http://theme.thephpleague.com/js/scripts.js"></script>
-<script src="http://theme.thephpleague.com/js/prism.js"></script>
+<script src="https://theme.thephpleague.com/js/scripts.js"></script>
+<script src="https://theme.thephpleague.com/js/prism.js"></script>
 
 {% if site.data.project.google_analytics_tracking_id %}
     <script>


### PR DESCRIPTION
site is broken over https, such as when using https://www.eff.org/https-everywhere