### PR TITLE
Allow for custom link URLs in JsonApiSerializer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - php: 7.0
     - php: 7.1
     - php: hhvm
+      dist: trusty
 
 install:
   - travis_retry composer install --no-interaction --prefer-source

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -84,7 +84,7 @@ class JsonApiSerializer extends ArraySerializer
 
         if ($this->shouldIncludeLinks()) {
             $resource['data']['links'] = [
-                'self' => "{$this->baseUrl}/$resourceKey/$id",
+                'self' => "{$this->baseUrl}/{$this->getTypePath($resourceKey)}/$id",
             ];
             if(isset($custom_links)) {
                 $resource['data']['links'] = array_merge($custom_links, $resource['data']['links']);
@@ -414,6 +414,17 @@ class JsonApiSerializer extends ArraySerializer
     }
 
     /**
+     * Maps a resource type to a URI path.
+     *
+     * @param string $type
+     * @return string
+     */
+    protected function getTypePath($type)
+    {
+       return $type;
+    }
+
+    /**
      * Check if the objects are part of a collection or not
      *
      * @param $includeObject
@@ -465,8 +476,8 @@ class JsonApiSerializer extends ArraySerializer
             if ($this->shouldIncludeLinks()) {
                 $data['data'][$index]['relationships'][$key] = array_merge([
                     'links' => [
-                        'self' => "{$this->baseUrl}/{$data['data'][$index]['type']}/{$data['data'][$index]['id']}/relationships/$key",
-                        'related' => "{$this->baseUrl}/{$data['data'][$index]['type']}/{$data['data'][$index]['id']}/$key",
+                        'self' => "{$this->baseUrl}/{$this->getTypePath($data['data'][$index]['type'])}/{$data['data'][$index]['id']}/relationships/$key",
+                        'related' => "{$this->baseUrl}/{$this->getTypePath($data['data'][$index]['type'])}/{$data['data'][$index]['id']}/$key",
                     ],
                 ], $data['data'][$index]['relationships'][$key]);
             }
@@ -490,8 +501,8 @@ class JsonApiSerializer extends ArraySerializer
         if ($this->shouldIncludeLinks()) {
             $data['data']['relationships'][$key] = array_merge([
                 'links' => [
-                    'self' => "{$this->baseUrl}/{$data['data']['type']}/{$data['data']['id']}/relationships/$key",
-                    'related' => "{$this->baseUrl}/{$data['data']['type']}/{$data['data']['id']}/$key",
+                    'self' => "{$this->baseUrl}/{$this->getTypePath($data['data']['type'])}/{$data['data']['id']}/relationships/$key",
+                    'related' => "{$this->baseUrl}/{$this->getTypePath($data['data']['type'])}/{$data['data']['id']}/$key",
                 ],
             ], $data['data']['relationships'][$key]);
 

--- a/test/Serializer/JsonApi/CustomTypePathTest.php
+++ b/test/Serializer/JsonApi/CustomTypePathTest.php
@@ -1,0 +1,86 @@
+<?php namespace League\Fractal\Test\Serializer;
+
+use League\Fractal\Manager;
+use League\Fractal\Resource\Item;
+use League\Fractal\Scope;
+use League\Fractal\Test\Stub\Serializer\JsonApiSerializerWithCustomTypePath;
+use League\Fractal\Test\Stub\Transformer\JsonApiBookTransformerWithSingularType;
+use Mockery;
+
+class CustomTypePathTest extends \PHPUnit_Framework_TestCase
+{
+    private $manager;
+
+    public function setUp()
+    {
+        $baseUrl = 'http://example.com';
+
+        $this->manager = new Manager();
+        $this->manager->setSerializer(new JsonApiSerializerWithCustomTypePath($baseUrl));
+    }
+
+    public function testSerializingItemResourceWithSelfLink()
+    {
+        $this->manager->parseIncludes('author');
+
+        $bookData = [
+            'id' => 1,
+            'title' => 'Foo',
+            'year' => '1991',
+            '_author' => [
+                'id' => 1,
+                'name' => 'Dave',
+            ],
+        ];
+
+        $resource = new Item($bookData, new JsonApiBookTransformerWithSingularType(), 'book');
+
+        $scope = new Scope($this->manager, $resource);
+
+        $expected = [
+            'data' => [
+                'type' => 'book',
+                'id' => '1',
+                'attributes' => [
+                    'title' => 'Foo',
+                    'year' => 1991,
+                ],
+                'links' => [
+                    'self' => 'http://example.com/books/1',
+                ],
+                'relationships' => [
+                    'author' => [
+                        'links' => [
+                            'self' => 'http://example.com/books/1/relationships/author',
+                            'related' => 'http://example.com/books/1/author',
+                        ],
+                        'data' => [
+                            'type' => 'person',
+                            'id' => '1',
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
+                    'type' => 'person',
+                    'id' => '1',
+                    'attributes' => [
+                        'name' => 'Dave',
+                    ],
+                    'links' => [
+                        'self' => 'http://example.com/persons/1',
+                    ],
+                ]
+            ],
+        ];
+
+        $this->assertSame($expected, $scope->toArray());
+        $this->assertSame(json_encode($expected), $scope->toJson());
+    }
+
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+}

--- a/test/Stub/Serializer/JsonApiSerializerWithCustomTypePath.php
+++ b/test/Stub/Serializer/JsonApiSerializerWithCustomTypePath.php
@@ -1,0 +1,17 @@
+<?php namespace League\Fractal\Test\Stub\Serializer;
+
+use League\Fractal\Serializer\JsonApiSerializer;
+
+class JsonApiSerializerWithCustomTypePath extends JsonApiSerializer
+{
+    protected function getTypePath($type)
+    {
+        // This would be a pluralize function
+        $map = [
+            'person' => 'persons',
+            'book' => 'books'
+        ];
+
+        return $map[$type];
+    }
+}

--- a/test/Stub/Transformer/JsonApiAuthorTransformerWithSingularType.php
+++ b/test/Stub/Transformer/JsonApiAuthorTransformerWithSingularType.php
@@ -1,0 +1,22 @@
+<?php namespace League\Fractal\Test\Stub\Transformer;
+
+use League\Fractal\TransformerAbstract;
+
+class JsonApiAuthorTransformerWithSingularType extends TransformerAbstract
+{
+    protected $availableIncludes = [
+        'published',
+    ];
+
+    public function transform(array $author)
+    {
+        unset($author['_published']);
+
+        return $author;
+    }
+
+    public function includePublished(array $author)
+    {
+        return $this->collection($author['_published'], new JsonApiBookTransformerWithSingularType(), 'book');
+    }
+}

--- a/test/Stub/Transformer/JsonApiBookTransformerWithSingularType.php
+++ b/test/Stub/Transformer/JsonApiBookTransformerWithSingularType.php
@@ -1,0 +1,23 @@
+<?php namespace League\Fractal\Test\Stub\Transformer;
+
+use League\Fractal\TransformerAbstract;
+
+class JsonApiBookTransformerWithSingularType extends TransformerAbstract
+{
+    protected $availableIncludes = [
+        'author'
+    ];
+
+    public function transform(array $book)
+    {
+        $book['year'] = (int) $book['year'];
+        unset($book['_author']);
+
+        return $book;
+    }
+
+    public function includeAuthor(array $book)
+    {
+        return $this->item($book['_author'], new JsonApiAuthorTransformerWithSingularType(), 'person');
+    }
+}


### PR DESCRIPTION
This PR adds a new protected function `getTypePath()` to the JsonApiSerializer which is internally used for generating URLs. Extending the JsonApiSerializer class and overriding this function allows for implementing a custom strategy for normalising endpoint URLs, i.e. when resource types and endpoint paths use singular/plural or vice versa.

This doesn't break any existing functionality afaik, but please do let me know if there's anything that can be improved.

See https://github.com/thephpleague/fractal/issues/230 for related discussion.