### PR TITLE
Update travis config to use trusty for hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - php: 7.0
     - php: 7.1
     - php: hhvm
+      dist: trusty
 
 install:
   - travis_retry composer install --no-interaction --prefer-source


### PR DESCRIPTION
Travis errors on hhvm builds with:

```
HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.
```

So let's `dist: trusty`