### PR TITLE
Allow array lists to parseFieldsets

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -233,8 +233,12 @@ class Manager
     {
         $this->requestedFieldsets = [];
         foreach ($fieldsets as $type => $fields) {
+            if (is_string($fields)) {
+                $fields = explode(',', $fields);
+            }
+
             //Remove empty and repeated fields
-            $this->requestedFieldsets[$type] = array_unique(array_filter(explode(',', $fields)));
+            $this->requestedFieldsets[$type] = array_unique(array_filter($fields));
         }
         return $this;
     }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -223,8 +223,8 @@ class Manager
     /**
      * Parse field parameter.
      *
-     * @param array $fieldsets Array of fields to include. It must be an array
-     *                         whose keys are resource types and values a string
+     * @param array $fieldsets Array of fields to include. It must be an array whose keys 
+     *                         are resource types and values an array or a string
      *                         of the fields to return, separated by a comma
      *
      * @return $this

--- a/test/ManagerTest.php
+++ b/test/ManagerTest.php
@@ -224,6 +224,10 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $manager->parseFieldsets(['foo' => 'bar,']);
         $this->assertSame(['foo' => ['bar']], $manager->getRequestedFieldsets());
 
+        // Verify you can send in arrays directly
+        $manager->parseFieldsets(['foo' => ['bar', 'baz']]);
+        $this->assertSame(['foo' => ['bar', 'baz']], $manager->getRequestedFieldsets());
+
         $this->assertSame(null, $manager->getFieldset('inexistent'));
     }
 


### PR DESCRIPTION
Hi. The `parseFieldsets` method of the Manager expects an array with strings, for then to parse it to an array. This PR adds a failing test and code satisfying the test allowing array of arrays to be passed directly.