### PR TITLE
convert links array to object if empty in ArraySerializer

### DIFF
--- a/src/Serializer/ArraySerializer.php
+++ b/src/Serializer/ArraySerializer.php
@@ -112,6 +112,10 @@ class ArraySerializer extends SerializerAbstract
             $pagination['links']['next'] = $paginator->getUrl($currentPage + 1);
         }
 
+        if (empty($pagination['links'])) {
+            $pagination['links'] = (object) [];
+        }
+
         return ['pagination' => $pagination];
     }
 


### PR DESCRIPTION
If paginator has no links it returns empty JSON array, but when it is not empty it returns object. It will be better if an object will be returned, even empty.