### PR TITLE
Preserve numeric keys in arrays

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -259,7 +259,7 @@ class Scope
                 );
             }
 
-            $data = array_merge($data, $includedData);
+            $data = $data + $includedData;
         }
 
         if ($this->resource instanceof Collection) {
@@ -285,7 +285,7 @@ class Scope
             return null;
         }
 
-        return array_merge($data, $meta);
+        return $data + $meta;
     }
 
     /**

--- a/test/ScopeTest.php
+++ b/test/ScopeTest.php
@@ -243,6 +243,20 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(['data' => ['bar' => 'baz', 'book' => ['yin' => 'yang'], 'price' => 99]], $scope->toArray());
     }
 
+    public function testToArrayWithNumericKeysPreserved()
+    {
+        $manager = new Manager();
+        $manager->setSerializer(new ArraySerializer());
+
+        $resource = new Item(['1' => 'First', '2' => 'Second'], function ($data) {
+            return $data;
+        });
+
+        $scope = new Scope($manager, $resource);
+
+        $this->assertSame(['1' => 'First', '2' => 'Second'], $scope->toArray());
+    }
+
     public function testToArrayWithSideloadedIncludes()
     {
         $serializer = Mockery::mock('League\Fractal\Serializer\ArraySerializer')->makePartial();


### PR DESCRIPTION
Use array union (`+` operator) instead of `array_merge` so that numeric keys within data are preserved.

Example: previously Fractal would convert

```
[
    '1' => 'First',
    '2' => 'Second',
    '5' => 'Fifth',
    'non-numeric' => 'Test',
]
```

to 

```
[
    '0' => 'First',
    '1' => 'Second',
    '2' => 'Fifth',
    'non-numeric' => 'Test',
]
```

Now the keys are preserved correctly.