### PR TITLE
Nested include for same type relationship fail in JsonApiSerializer

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -188,7 +188,7 @@ class JsonApiSerializer extends ArraySerializer
             }
         }
 
-        return empty($serializedData) ? [] : ['included' => $serializedData];
+        return empty($serializedData) ? [] : ['included' => array_values($serializedData)];
     }
 
     /**
@@ -584,10 +584,19 @@ class JsonApiSerializer extends ArraySerializer
             $includeId = $object['id'];
             $cacheKey = "$includeType:$includeId";
             if (!array_key_exists($cacheKey, $linkedIds)) {
-                $serializedData[] = $object;
+                $serializedData[$cacheKey] = $object;
                 $linkedIds[$cacheKey] = $object;
+            } elseif (isset($object['relationships'])) {
+                // Preserve nested relationships
+                if (isset($serializedData[$cacheKey]['relationships'])) {
+                    $serializedData[$cacheKey]['relationships'] = array_merge($serializedData[$cacheKey]['relationships'],
+                        $object['relationships']);
+                } else {
+                    $serializedData[$cacheKey]['relationships'] = $object['relationships'];
+                }
             }
         }
+
         return [$serializedData, $linkedIds];
     }
 }

--- a/test/Serializer/JsonApi/CircularTypeTest.php
+++ b/test/Serializer/JsonApi/CircularTypeTest.php
@@ -1,0 +1,296 @@
+<?php namespace League\Fractal\Test\Serializer;
+
+use League\Fractal\Manager;
+use League\Fractal\Resource\Collection;
+use League\Fractal\Scope;
+use League\Fractal\Serializer\JsonApiSerializer;
+use League\Fractal\Test\Stub\Transformer\JsonApiCircularTypeAuthorTransformer;
+use League\Fractal\Test\Stub\Transformer\JsonApiCircularTypeBookTransformer;
+use Mockery;
+
+class CircularTypeTest extends \PHPUnit_Framework_TestCase
+{
+    private $manager;
+
+    public function setUp()
+    {
+        $this->manager = new Manager();
+        $this->manager->setSerializer(new JsonApiSerializer());
+    }
+
+    public function testSerializingWithSingleCircularTypeReference()
+    {
+        $this->manager->parseIncludes('prequel');
+
+        $bookData = [
+            [
+                'id' => 1,
+                'title' => 'Foo',
+            ],
+            [
+                'id' => 2,
+                'title' => 'Bar',
+                '_prequel' => [
+                    'id' => 1,
+                    'title' => 'Foo',
+                ],
+            ],
+            [
+                'id' => 3,
+                'title' => 'Baz',
+                '_prequel' => [
+                    'id' => 2,
+                    'title' => 'Bar',
+                ],
+            ]
+        ];
+
+        $resources = new Collection($bookData, new JsonApiCircularTypeBookTransformer(), 'book');
+        $scope = new Scope($this->manager, $resources);
+
+        $expected = [
+            'data' => [
+                [
+                    'type' => 'book',
+                    'id' => '1',
+                    'attributes' => ['title' => 'Foo'],
+                ],
+                [
+                    'type' => 'book',
+                    'id' => '2',
+                    'attributes' => ['title' => 'Bar'],
+                    'relationships' => [
+                        'prequel' => [
+                            'data' => ['type' => 'book', 'id' => '1'],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'book',
+                    'id' => '3',
+                    'attributes' => ['title' => 'Baz'],
+                    'relationships' => [
+                        'prequel' => [
+                            'data' => ['type' => 'book', 'id' => '2'],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => []
+        ];
+
+        $this->assertSame($expected, $scope->toArray());
+        $this->assertSame(json_encode($expected), $scope->toJson());
+    }
+
+    public function testSerializingWithMultipleCircularTypeReferences()
+    {
+        $this->manager->parseIncludes('prequel');
+
+        $bookData = [
+            [
+                'id' => 1,
+                'title' => 'Foo',
+            ],
+            [
+                'id' => 2,
+                'title' => 'Bar',
+                '_prequel' => [
+                    'id' => 1,
+                    'title' => 'Foo',
+                ],
+            ],
+            [
+                'id' => 3,
+                'title' => 'Baz',
+                '_prequel' => [
+                    'id' => 2,
+                    'title' => 'Bar',
+                ],
+            ],
+            [
+                'id' => 4,
+                'title' => 'Baq',
+                '_prequel' => [
+                    'id' => 2,
+                    'title' => 'Bar',
+                ],
+            ]
+        ];
+
+        $resources = new Collection($bookData, new JsonApiCircularTypeBookTransformer(), 'book');
+        $scope = new Scope($this->manager, $resources);
+
+        $expected = [
+            'data' => [
+                [
+                    'type' => 'book',
+                    'id' => '1',
+                    'attributes' => ['title' => 'Foo'],
+                ],
+                [
+                    'type' => 'book',
+                    'id' => '2',
+                    'attributes' => ['title' => 'Bar'],
+                    'relationships' => [
+                        'prequel' => [
+                            'data' => ['type' => 'book', 'id' => '1'],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'book',
+                    'id' => '3',
+                    'attributes' => ['title' => 'Baz'],
+                    'relationships' => [
+                        'prequel' => [
+                            'data' => ['type' => 'book', 'id' => '2'],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'book',
+                    'id' => '4',
+                    'attributes' => ['title' => 'Baq'],
+                    'relationships' => [
+                        'prequel' => [
+                            'data' => ['type' => 'book', 'id' => '2'],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => []
+        ];
+
+        $this->assertSame($expected, $scope->toArray());
+        $this->assertSame(json_encode($expected), $scope->toJson());
+    }
+
+    public function testSerializingWithNestedSingleCircularTypeReference()
+    {
+        $this->manager->parseIncludes('books,books.prequel');
+
+        $data = [
+            [
+                'id' => 1,
+                'name' => 'Author 1',
+                '_books' => [
+                    [
+                        'id' => 1,
+                        'title' => 'Book 1',
+                    ],
+                    [
+                        'id' => 2,
+                        'title' => 'Book 2',
+                        '_prequel' => [
+                            'id' => 1,
+                            'title' => 'Book 1',
+                        ],
+                    ],
+                ]
+            ],
+            [
+                'id' => 2,
+                'name' => 'Author 2',
+                '_books' => [
+                    [
+                        'id' => 3,
+                        'title' => 'Book 3',
+                        '_prequel' => [
+                            'id' => 2,
+                            'title' => 'Book 2',
+                        ],
+                    ],
+                    [
+                        'id' => 4,
+                        'title' => 'Book 4',
+                        '_prequel' => [
+                            'id' => 3,
+                            'title' => 'Book 3',
+                        ],
+                    ],
+                ]
+            ],
+        ];
+
+        $resources = new Collection($data, new JsonApiCircularTypeAuthorTransformer(), 'author');
+        $scope = new Scope($this->manager, $resources);
+
+        $expected = [
+            'data' => [
+                [
+                    'type' => 'author',
+                    'id' => '1',
+                    'attributes' => ['name' => 'Author 1'],
+                    'relationships' => [
+                        'books' => [
+                            'data' => [
+                                ['type' => 'book', 'id' => '1'],
+                                ['type' => 'book', 'id' => '2'],
+                            ]
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'author',
+                    'id' => '2',
+                    'attributes' => ['name' => 'Author 2'],
+                    'relationships' => [
+                        'books' => [
+                            'data' => [
+                                ['type' => 'book', 'id' => '3'],
+                                ['type' => 'book', 'id' => '4'],
+                            ]
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
+                    'type' => 'book',
+                    'id' => '1',
+                    'attributes' => ['title' => 'Book 1'],
+                ],
+                [
+                    'type' => 'book',
+                    'id' => '2',
+                    'attributes' => ['title' => 'Book 2'],
+                    'relationships' => [
+                        'prequel' => [
+                            'data' => ['type' => 'book', 'id' => '1'],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'book',
+                    'id' => '3',
+                    'attributes' => ['title' => 'Book 3'],
+                    'relationships' => [
+                        'prequel' => [
+                            'data' => ['type' => 'book', 'id' => '2'],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'book',
+                    'id' => '4',
+                    'attributes' => ['title' => 'Book 4'],
+                    'relationships' => [
+                        'prequel' => [
+                            'data' => ['type' => 'book', 'id' => '3'],
+                        ],
+                    ],
+                ],
+            ]
+        ];
+
+        $this->assertSame(json_encode($expected, JSON_PRETTY_PRINT), $scope->toJson(JSON_PRETTY_PRINT));
+        $this->assertSame($expected, $scope->toArray());
+    }
+
+
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+}

--- a/test/Stub/Transformer/JsonApiCircularTypeAuthorTransformer.php
+++ b/test/Stub/Transformer/JsonApiCircularTypeAuthorTransformer.php
@@ -1,0 +1,26 @@
+<?php namespace League\Fractal\Test\Stub\Transformer;
+
+use League\Fractal\TransformerAbstract;
+
+class JsonApiCircularTypeAuthorTransformer extends TransformerAbstract
+{
+    protected $availableIncludes = [
+        'books'
+    ];
+
+    public function transform(array $author)
+    {
+        unset($author['_books']);
+
+        return $author;
+    }
+
+    public function includeBooks(array $author)
+    {
+        if (!array_key_exists('_books', $author)) {
+            return;
+        }
+
+        return $this->collection($author['_books'], new JsonApiCircularTypeBookTransformer(), 'book');
+    }
+}

--- a/test/Stub/Transformer/JsonApiCircularTypeBookTransformer.php
+++ b/test/Stub/Transformer/JsonApiCircularTypeBookTransformer.php
@@ -1,0 +1,26 @@
+<?php namespace League\Fractal\Test\Stub\Transformer;
+
+use League\Fractal\TransformerAbstract;
+
+class JsonApiCircularTypeBookTransformer extends TransformerAbstract
+{
+    protected $availableIncludes = [
+        'prequel'
+    ];
+
+    public function transform(array $book)
+    {
+        unset($book['_prequel']);
+
+        return $book;
+    }
+
+    public function includePrequel(array $book)
+    {
+        if (!array_key_exists('_prequel', $book)) {
+            return;
+        }
+
+        return $this->item($book['_prequel'], new self(), 'book');
+    }
+}


### PR DESCRIPTION
When requesting nested includes of the same resource type, JsonApiSerializer incorrectly merges the results in the `included` object.

For example, when requesting includes in the form of `books,books.prequel` for a collection of authors, where:

1. the _books_ include is of resource type _books_, and
2. the _books.prequel_ include is of the resource type _books_ as well,

the `included` object only includes nested relationships for those books which are not referenced as a relationship in another book.

If this all sounds a little abstract, please take a look at the attached test case.