### PR TITLE
Properly merge self link for JsonApiSerializer

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -87,7 +87,7 @@ class JsonApiSerializer extends ArraySerializer
                 'self' => "{$this->baseUrl}/$resourceKey/$id",
             ];
             if(isset($custom_links)) {
-                $resource['data']['links'] = array_merge($custom_links, $resource['data']['links']);
+                $resource['data']['links'] = array_merge($resource['data']['links'], $custom_links);
             }
         }
 

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -2117,8 +2117,8 @@ class JsonApiSerializerTest extends TestCase
                     'year' => 1991,
                 ],
                 'links' => [
-                    'custom_link' => '/custom/link',
                     'self' => 'http://test.de/books/1',
+                    'custom_link' => '/custom/link',
                 ]
             ],
         ];
@@ -2155,6 +2155,45 @@ class JsonApiSerializerTest extends TestCase
                 ],
                 'links' => [
                     'self' => 'http://test.de/books/1',
+                ]
+            ],
+        ];
+
+        $this->assertSame(json_encode($expected), $scope->toJson());
+    }
+
+    public function testCustomSelfLinkMerge()
+    {
+        $manager = new Manager();
+        $manager->setSerializer(new JsonApiSerializer('http://test.de'));
+
+        $bookData = [
+            'id' => 1,
+            'title' => 'Foo',
+            'year' => '1991',
+            '_author' => [
+                'id' => 1,
+                'name' => 'Dave',
+            ],
+            'links' => [
+                'self' => '/custom/link',
+            ],
+        ];
+
+        $resource = new Item($bookData, new JsonApiBookTransformer('test.de'), 'books');
+
+        $scope = new Scope($manager, $resource);
+
+        $expected = [
+            'data' => [
+                'type' => 'books',
+                'id' => '1',
+                'attributes' => [
+                    'title' => 'Foo',
+                    'year' => 1991,
+                ],
+                'links' => [
+                    'self' => '/custom/link',
                 ]
             ],
         ];


### PR DESCRIPTION
• Reference Issue #420 
• Allow provided self link to overwrite default generated self link
• Provide test for this merge case: testCustomSelfLinkMerge()
• Alter expected results for testCustomLinkMerge() due to change in array_merge parameter order