### PR TITLE
Allow the 'self' link to be overridden

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -87,7 +87,7 @@ class JsonApiSerializer extends ArraySerializer
                 'self' => "{$this->baseUrl}/$resourceKey/$id",
             ];
             if(isset($custom_links)) {
-                $resource['data']['links'] = array_merge($custom_links, $resource['data']['links']);
+                $resource['data']['links'] = array_merge($resource['data']['links'], $custom_links);
             }
         }
 


### PR DESCRIPTION
The format for the automatically generated `self` link is sometimes wrong. E.g. with parent/child resources (`users/1/basket`). This allows an override of the `self` link via the `links()` method in the Transformers without changing any of the other behaviour of the custom links.