### PR TITLE
Convert attributes to empty object if there are no attributes

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -82,6 +82,10 @@ class JsonApiSerializer extends ArraySerializer
             unset($resource['data']['attributes']['meta']);
         }
 
+        if(empty($resource['data']['attributes'])) {
+            $resource['data']['attributes'] = (object) [];
+        }
+
         if ($this->shouldIncludeLinks()) {
             $resource['data']['links'] = [
                 'self' => "{$this->baseUrl}/$resourceKey/$id",

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -7,6 +7,7 @@ use League\Fractal\Scope;
 use League\Fractal\Serializer\JsonApiSerializer;
 use League\Fractal\Test\Stub\Transformer\JsonApiAuthorTransformer;
 use League\Fractal\Test\Stub\Transformer\JsonApiBookTransformer;
+use League\Fractal\Test\Stub\Transformer\JsonApiEmptyTransformer;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
@@ -2252,6 +2253,22 @@ class JsonApiSerializerTest extends TestCase
         ];
 
         $this->assertSame(json_encode($expected), $scope->toJson());
+    }
+
+    public function testEmptyAttributesIsObject()
+    {
+        $manager = new Manager();
+        $manager->setSerializer(new JsonApiSerializer());
+
+        $data = ['id' => 1];
+
+        $resource = new Item($data, new JsonApiEmptyTransformer(), 'resources');
+
+        $scope = new Scope($manager, $resource);
+
+        $expectedJson = '{"data":{"type":"resources","id":"1","attributes":{}}}';
+
+        $this->assertSame($expectedJson, $scope->toJson());
     }
 
     /**

--- a/test/Stub/Transformer/JsonApiEmptyTransformer.php
+++ b/test/Stub/Transformer/JsonApiEmptyTransformer.php
@@ -1,0 +1,11 @@
+<?php namespace League\Fractal\Test\Stub\Transformer;
+
+use League\Fractal\TransformerAbstract;
+
+class JsonApiEmptyTransformer extends TransformerAbstract
+{
+    public function transform(array $resource)
+    {
+        return $resource;
+    }
+}


### PR DESCRIPTION
If you transform a resource without any attributes using the JsonApiSerializer the resulting JSON currently looks like `"attributes": []`. This does not satisfy the JSON API spec: [The value of the attributes key MUST be an object (an “attributes object”).](http://jsonapi.org/format/#document-resource-object-attributes).
It would also be possible to remove the entire attributes key from the resource object, since JSON API does not require it. However, I think many clients expect there to be an attributes key, so it is better to set it to an empty object. It just can't be an array.

If you would like me to make any changes to the pull request, don't hesitate to ask.