### PR TITLE
Performance improvement for Phalcon Paginator

### DIFF
--- a/src/Pagination/PhalconFrameworkPaginatorAdapter.php
+++ b/src/Pagination/PhalconFrameworkPaginatorAdapter.php
@@ -23,7 +23,7 @@ class PhalconFrameworkPaginatorAdapter implements PaginatorInterface
     /**
      * A slice of the result set to show in the pagination
      *
-     * @var \Phalcon\Paginator\AdapterInterface
+     * @var stdClass
      */
     private $paginator;
 

--- a/src/Pagination/PhalconFrameworkPaginatorAdapter.php
+++ b/src/Pagination/PhalconFrameworkPaginatorAdapter.php
@@ -23,11 +23,15 @@ class PhalconFrameworkPaginatorAdapter implements PaginatorInterface
     /**
      * A slice of the result set to show in the pagination
      *
-     * @var stdClass
+     * @var \stdClass
      */
     private $paginator;
 
-    
+    /**
+     * PhalconFrameworkPaginatorAdapter constructor.
+     *
+     * @param stdClass $paginator
+     */
     public function __construct($paginator)
     {
         $this->paginator = $paginator;

--- a/src/Pagination/PhalconFrameworkPaginatorAdapter.php
+++ b/src/Pagination/PhalconFrameworkPaginatorAdapter.php
@@ -15,7 +15,8 @@ namespace League\Fractal\Pagination;
  * A paginator adapter for PhalconPHP/pagination.
  *
  * @author Thien Tran <fcduythien@gmail.com>
- * 
+ * @author Nikolaos Dimopoulos <nikos@phalconphp.com>
+ *
  */
 class PhalconFrameworkPaginatorAdapter implements PaginatorInterface
 {
@@ -29,7 +30,7 @@ class PhalconFrameworkPaginatorAdapter implements PaginatorInterface
     
     public function __construct($paginator)
     {
-        $this->paginator = $paginator->getPaginate();
+        $this->paginator = $paginator;
     }
 
     /**

--- a/test/Pagination/PhalconFrameworkPaginatorAdapterTest.php
+++ b/test/Pagination/PhalconFrameworkPaginatorAdapterTest.php
@@ -2,7 +2,6 @@
 
 namespace League\Fractal\Test\Pagination;
 
-use function array_fill;
 use League\Fractal\Pagination\PhalconFrameworkPaginatorAdapter;
 use PHPUnit\Framework\TestCase;
 

--- a/test/Pagination/PhalconFrameworkPaginatorAdapterTest.php
+++ b/test/Pagination/PhalconFrameworkPaginatorAdapterTest.php
@@ -2,46 +2,31 @@
 
 namespace League\Fractal\Test\Pagination;
 
+use function array_fill;
 use League\Fractal\Pagination\PhalconFrameworkPaginatorAdapter;
-use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class PhalconFrameworkPaginatorAdapterTest extends TestCase
 {
     public function testPaginationAdapter()
     {
-        $total = 50;
-        $count = 10;
-        $perPage = 10;
-        $currentPage = 2;
-        $lastPage = 5;
+        $resultset = new \stdClass();
+        $resultset->items       = array_fill(1, 50, 'fractal');
+        $resultset->current     = 3;
+        $resultset->first       = 1;
+        $resultset->last        = 5;
+        $resultset->next        = 4;
+        $resultset->previous    = 2;
+        $resultset->total_items = 50;
+        $resultset->total_pages = 10;
 
-        $paginate =[
-            'last'        => $lastPage,
-            'current'     => $currentPage,
-            'total_items' => $total,
-            'total_pages' => $count,
-
-        ];
-
-        $paginator = Mockery::mock('Phalcon\Paginator\Adapter\QueryBuilder');
-        $paginator->shouldReceive('currentPage')->andReturn($currentPage);
-        $paginator->shouldReceive('lastPage')->andReturn($lastPage);
-        $paginator->shouldReceive('count')->andReturn($count);
-        $paginator->shouldReceive('total')->andReturn($total);
-        $paginator->shouldReceive('getPaginate')->andReturn((object) $paginate);
-
-        $adapter = new PhalconFrameworkPaginatorAdapter($paginator);
-
+        $adapter = new PhalconFrameworkPaginatorAdapter($resultset);
         $this->assertInstanceOf('League\Fractal\Pagination\PaginatorInterface', $adapter);
-        $this->assertSame($currentPage, $adapter->getCurrentPage());
-        $this->assertSame($lastPage, $adapter->getLastPage());
-        $this->assertSame($count, $adapter->getCount());
-        $this->assertSame($total, $adapter->getTotal());
-    }
-
-    public function tearDown()
-    {
-        Mockery::close();
+        $this->assertSame(3, $adapter->getCurrentPage());
+        $this->assertSame(10, $adapter->getCount());
+        $this->assertSame(50, $adapter->getTotal());
+        $this->assertSame(10, $adapter->getPerPage());
+        $this->assertSame(5, $adapter->getLastPage());
+        $this->assertSame(4, $adapter->getNext());
     }
 }

--- a/test/Pagination/PhalconFrameworkPaginatorAdapterTest.php
+++ b/test/Pagination/PhalconFrameworkPaginatorAdapterTest.php
@@ -11,7 +11,7 @@ class PhalconFrameworkPaginatorAdapterTest extends TestCase
     public function testPaginationAdapter()
     {
         $resultset = new \stdClass();
-        $resultset->items       = array_fill(1, 50, 'fractal');
+        $resultset->items       = array_fill(1, 10, 'fractal');
         $resultset->current     = 3;
         $resultset->first       = 1;
         $resultset->last        = 5;


### PR DESCRIPTION
The Phalcon paginator used to accept a paginator object and in the constructor would use the `getPaginate()` method which executes a database query. The same method was used prior to invoking the paginator to set up the `Collection` object. 

Therefore the Phalcon paginator was executing two queries instead of just one, thus rendering caching techniques useless.

This PR solves this issue by altering the paginator to accept the `stdClass` object that the Phalcon paginator returns.