### PR TITLE
Implement \JsonSerializable for Scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 - Add links for all available includes to `JsonApiSerializer` #331 - Thanks @matt-allan
+- Implement interface `\JsonSerializable` in Scopes to allow for direct usage with `json_encode()`
 
 
 

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -26,7 +26,7 @@ use League\Fractal\Serializer\SerializerAbstract;
  * context. For example, the same resource could be attached to multiple scopes.
  * There are root scopes, parent scopes and child scopes.
  */
-class Scope
+class Scope implements \JsonSerializable
 {
     /**
      * @var array
@@ -293,6 +293,14 @@ class Scope
     }
 
     /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+  /**
      * Convert the current data for this scope to JSON.
      *
      * @param int $options
@@ -301,7 +309,7 @@ class Scope
      */
     public function toJson($options = 0)
     {
-        return json_encode($this->toArray(), $options);
+        return json_encode($this, $options);
     }
 
     /**

--- a/test/ScopeTest.php
+++ b/test/ScopeTest.php
@@ -72,6 +72,23 @@ class ScopeTest extends TestCase
         $this->assertSame(['data' => ['foo' => 'bar']], $scope->toArray());
     }
 
+    /**
+     * @covers \League\Fractal\Scope::jsonSerialize()
+     */
+    public function testJsonSerializable()
+    {
+        $manager = new Manager();
+
+        $resource = new Item(['foo' => 'bar'], function ($data) {
+            return $data;
+        });
+
+        $scope = new Scope($manager, $resource);
+
+        $this->assertInstanceOf('\JsonSerializable', $scope);
+        $this->assertEquals($scope->jsonSerialize(), $scope->toArray());
+    }
+
     public function testToJson()
     {
         $data = [


### PR DESCRIPTION
So the idea here may have already been a thing...but I'd like to propose implementing \JsonSerializable on Scopes.

It saves a call to `toArray()` and would allow for Scopes to be passed directly to `json_encode()`

This saves a little time depending on how mocky / stubby your tests get in your consumer implementation as there is one less message to pass through with whatever value you're interested in returning / asserting against. 

So in our codebase (and I assume some others) our controller or responder might look like

```php

$this->respond($this->manager->createData($resource)->toArray());

// OR

$this->respond($this->manager->createData($resource));

// to test with mocks we have to mock a Scope and stub `toArray()` and assert on that
// or we could just assert that the responder method is is called with the mock
```

Basically it's one less part of the message chain here and can hopefully make people's lives a little easier. Could totally be wrong though! Not everyone uses this the same way. 

Either way, thank you contributors for making such a great library that solves some highly obvious pain-points that are rarely addressed in php api land.
