### PR TITLE
Fix phpDoc param typehint for setters in Cursor class

### DIFF
--- a/src/Pagination/Cursor.php
+++ b/src/Pagination/Cursor.php
@@ -78,7 +78,7 @@ class Cursor implements CursorInterface
     /**
      * Set the current cursor value.
      *
-     * @param int $current
+     * @param mixed $current
      *
      * @return Cursor
      */
@@ -102,7 +102,7 @@ class Cursor implements CursorInterface
     /**
      * Set the prev cursor value.
      *
-     * @param int $prev
+     * @param mixed $prev
      *
      * @return Cursor
      */
@@ -126,7 +126,7 @@ class Cursor implements CursorInterface
     /**
      * Set the next cursor value.
      *
-     * @param int $next
+     * @param mixed $next
      *
      * @return Cursor
      */


### PR DESCRIPTION
Change typehints in the phpDoc for the setters to match CursorInterface types.