### PR TITLE
Allow HHVM to fail so that tests can complete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
     - php: hhvm
       dist: trusty
 
+  allow_failures:
+    - php: hhvm
+
 install:
   - travis_retry composer install --no-interaction --prefer-source
 


### PR DESCRIPTION
HHVM is failing due to an issue with composer. Let's just ignore HHVM failures for now and decide what to do with it later.