### PR TITLE
Allow non-array values to flow out from transformers

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -241,7 +241,7 @@ class Scope
         // If the serializer wants the includes to be side-loaded then we'll
         // serialize the included data and merge it with the data.
         if ($serializer->sideloadIncludes()) {
-            //Filter out any relation that wasn't requested
+            // Filter out any relation that wasn't requested
             $rawIncludedData = array_map(array($this, 'filterFieldsets'), $rawIncludedData);
 
             $includedData = $serializer->includedData($this->resource, $rawIncludedData);
@@ -277,7 +277,7 @@ class Scope
         // Pull out all of OUR metadata and any custom meta data to merge with the main level data
         $meta = $serializer->meta($this->resource->getMeta());
 
-        // in case of returning NullResource we should return null and not to go with array_merge
+        // In case of returning NullResource we should return null and not to go with array_merge
         if (is_null($data)) {
             if (!empty($meta)) {
                 return $meta;
@@ -412,8 +412,10 @@ class Scope
             $transformedData = $this->manager->getSerializer()->mergeIncludes($transformedData, $includedData);
         }
 
-        //Stick only with requested fields
-        $transformedData = $this->filterFieldsets($transformedData);
+        // Stick only with requested fields if we have more than one
+        if (is_array($transformedData)) {
+            $transformedData = $this->filterFieldsets($transformedData);
+        }
 
         return [$transformedData, $includedData];
     }
@@ -473,7 +475,7 @@ class Scope
      * @internal
      *
      * @param array  $data
-     *
+     *g
      * @return array
      */
     protected function filterFieldsets(array $data)
@@ -483,7 +485,7 @@ class Scope
         }
         $serializer = $this->manager->getSerializer();
         $requestedFieldset = iterator_to_array($this->getFilterFieldset());
-        //Build the array of requested fieldsets with the mandatory serializer fields
+        // Build the array of requested fieldsets with the mandatory serializer fields
         $filterFieldset = array_flip(
             array_merge(
                 $serializer->getMandatoryFields(),

--- a/test/Serializer/ArraySerializerTest.php
+++ b/test/Serializer/ArraySerializerTest.php
@@ -331,6 +331,16 @@ class ArraySerializerTest extends TestCase
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
+    public function testSerializingPrimitiveValueCollection()
+    {
+        $manager = new Manager();
+        $resource = new Collection(['foo', 'bar', 'baz'], function($string) {
+            return $string;
+        });
+
+        $this->assertSame('{"data":["foo","bar","baz"]}', $manager->createData($resource)->toJson());
+    }
+
     public function tearDown()
     {
         Mockery::close();


### PR DESCRIPTION
Fixes #466

Before this change if we had a transformer like:
```
function ($anything): string {
    return "foo";
}
```

we would run into errors due to `string` being passed where an `array` is required. This is because our `Scope` class would attempt to filter the array keys down to just what was requested and obviously fails because we're not dealing with arrays.

To resolve this I've just skipped the scope key filtering step when we're given something other than an array.