### PR TITLE
Allow for scoped serialization

### DIFF
--- a/src/Scope.php
+++ b/src/Scope.php
@@ -273,6 +273,14 @@ class Scope
                 $this->resource->setMetaValue(key($pagination), current($pagination));
             }
         }
+        // Daves monkey patch to allow Items to have pagination
+        elseif ($this->resource instanceof Item && empty($this->getIdentifier()) && method_exists($this->resource, 'getPaginator')) {
+            $pagination = $serializer->paginator($this->resource->getPaginator());
+
+            if (! empty($pagination)) {
+                $this->resource->setMetaValue(key($pagination), current($pagination));
+            }
+        }
 
         // Pull out all of OUR metadata and any custom meta data to merge with the main level data
         $meta = $serializer->meta($this->resource->getMeta());

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -374,9 +374,10 @@ class Scope
     protected function serializeResource(SerializerAbstract $serializer, $data)
     {
         $resourceKey = $this->resource->getResourceKey();
+        $identifier = $this->getIdentifier();
 
         if ($this->resource instanceof Collection) {
-            return $serializer->collection($resourceKey, $data);
+            return $serializer->collection($resourceKey, $data, $identifier);
         }
 
         if ($this->resource instanceof Item) {

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -381,7 +381,7 @@ class Scope
         }
 
         if ($this->resource instanceof Item) {
-            return $serializer->item($resourceKey, $data);
+            return $serializer->item($resourceKey, $data, $identifier);
         }
 
         return $serializer->null();

--- a/src/Serializer/ArraySerializer.php
+++ b/src/Serializer/ArraySerializer.php
@@ -36,10 +36,11 @@ class ArraySerializer extends SerializerAbstract
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string|null $identifier
      *
      * @return array
      */
-    public function item($resourceKey, array $data)
+    public function item($resourceKey, array $data, $identifier = null)
     {
         return $data;
     }

--- a/src/Serializer/ArraySerializer.php
+++ b/src/Serializer/ArraySerializer.php
@@ -26,7 +26,7 @@ class ArraySerializer extends SerializerAbstract
      *
      * @return array
      */
-    public function collection($resourceKey, array $data, ?string $identifier)
+    public function collection($resourceKey, array $data, $identifier = null)
     {
         return [$resourceKey ?: 'data' => $data];
     }

--- a/src/Serializer/ArraySerializer.php
+++ b/src/Serializer/ArraySerializer.php
@@ -22,10 +22,11 @@ class ArraySerializer extends SerializerAbstract
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string|null $identifier
      *
      * @return array
      */
-    public function collection($resourceKey, array $data)
+    public function collection($resourceKey, array $data, ?string $identifier)
     {
         return [$resourceKey ?: 'data' => $data];
     }

--- a/src/Serializer/DataArraySerializer.php
+++ b/src/Serializer/DataArraySerializer.php
@@ -22,7 +22,7 @@ class DataArraySerializer extends ArraySerializer
      *
      * @return array
      */
-    public function collection($resourceKey, array $data, ?string $identifier)
+    public function collection($resourceKey, array $data, $identifier = null)
     {
         return ['data' => $data];
     }

--- a/src/Serializer/DataArraySerializer.php
+++ b/src/Serializer/DataArraySerializer.php
@@ -18,10 +18,11 @@ class DataArraySerializer extends ArraySerializer
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string|null $identifier
      *
      * @return array
      */
-    public function collection($resourceKey, array $data)
+    public function collection($resourceKey, array $data, ?string $identifier)
     {
         return ['data' => $data];
     }

--- a/src/Serializer/DataArraySerializer.php
+++ b/src/Serializer/DataArraySerializer.php
@@ -32,10 +32,11 @@ class DataArraySerializer extends ArraySerializer
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string|null $identifier
      *
      * @return array
      */
-    public function item($resourceKey, array $data)
+    public function item($resourceKey, array $data, $identifier = null)
     {
         return ['data' => $data];
     }

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -36,10 +36,11 @@ class JsonApiSerializer extends ArraySerializer
      *
      * @param string $resourceKey
      * @param array $data
+     * @param string|null $identifier
      *
      * @return array
      */
-    public function collection($resourceKey, array $data)
+    public function collection($resourceKey, array $data, ?string $identifier)
     {
         $resources = [];
 

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -56,10 +56,11 @@ class JsonApiSerializer extends ArraySerializer
      *
      * @param string $resourceKey
      * @param array $data
+     * @param string|null $identifier
      *
      * @return array
      */
-    public function item($resourceKey, array $data)
+    public function item($resourceKey, array $data, $identifier = null)
     {
         $id = $this->getIdFromData($data);
 

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -40,7 +40,7 @@ class JsonApiSerializer extends ArraySerializer
      *
      * @return array
      */
-    public function collection($resourceKey, array $data, ?string $identifier)
+    public function collection($resourceKey, array $data, $identifier = null)
     {
         $resources = [];
 

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -23,10 +23,11 @@ interface Serializer
      *
      * @param string $resourceKey
      * @param array $data
+     * @param string|null $identifier
      *
      * @return array
      */
-    public function item($resourceKey, array $data);
+    public function item($resourceKey, array $data, $identifier = null);
 
     /**
      * Serialize null resource.

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -12,10 +12,11 @@ interface Serializer
      *
      * @param string $resourceKey
      * @param array $data
+     * @param string|null $identifier
      *
      * @return array
      */
-    public function collection($resourceKey, array $data);
+    public function collection($resourceKey, array $data, ?string $identifier);
 
     /**
      * Serialize an item.

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -16,7 +16,7 @@ interface Serializer
      *
      * @return array
      */
-    public function collection($resourceKey, array $data, ?string $identifier);
+    public function collection($resourceKey, array $data, $identifier = null);
 
     /**
      * Serialize an item.

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -33,10 +33,11 @@ abstract class SerializerAbstract implements Serializer
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string|null $identifier
      *
      * @return array
      */
-    abstract public function item($resourceKey, array $data);
+    abstract public function item($resourceKey, array $data, $identifier = null);
 
     /**
      * Serialize null resource.

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -26,7 +26,7 @@ abstract class SerializerAbstract implements Serializer
      *
      * @return array
      */
-    abstract public function collection($resourceKey, array $data, ?string $identifier);
+    abstract public function collection($resourceKey, array $data, $identifier = null);
 
     /**
      * Serialize an item.

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -22,10 +22,11 @@ abstract class SerializerAbstract implements Serializer
      *
      * @param string $resourceKey
      * @param array  $data
+     * @param string|null $identifier
      *
      * @return array
      */
-    abstract public function collection($resourceKey, array $data);
+    abstract public function collection($resourceKey, array $data, ?string $identifier);
 
     /**
      * Serialize an item.


### PR DESCRIPTION
We have been implementing Fractal in order to refactor the generation of an existing web service response. To this end we need to preserve our existing response format.

This aim of this PR is to introduce the scope identifier into the Serializer interface. This allows custom serializers, like our own, to better understand what is being serialized in that execution and react accordingly.

The change complies with PSR2, but I'm unsure really what sort of test-case to add for the change. If you have a suggestion, I can implement a test-case.

As the new parameter is nullable it will cause a change to the public api, but is backwards compatible.

Apologies, but I'm also unsure how to update your documentation, as it says to do in your contribution guidelines.