### PR TITLE
Allow use of newer PHPUnit on newer versions of PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "illuminate/contracts": "~5.0",
         "mockery/mockery": "~0.9",
         "pagerfanta/pagerfanta": "~1.0.0",
-        "phpunit/phpunit": "^4.8.35",
+        "phpunit/phpunit": "^4.8.35 || ^7.5",
         "squizlabs/php_codesniffer": "~1.5",
         "zendframework/zend-paginator": "~2.3"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/test/ScopeFactoryTest.php
+++ b/test/ScopeFactoryTest.php
@@ -69,7 +69,7 @@ class ScopeFactoryTest extends TestCase
      */
     private function createManager()
     {
-        return $this->getMock('League\\Fractal\\Manager');
+        return $this->getMockBuilder('League\\Fractal\\Manager')->getMock();
     }
 
     /**
@@ -77,6 +77,6 @@ class ScopeFactoryTest extends TestCase
      */
     private function createResource()
     {
-        return $this->getMock('League\\Fractal\\Resource\\ResourceInterface');
+        return $this->getMockBuilder('League\\Fractal\\Resource\\ResourceInterface')->getMock();
     }
 }

--- a/test/TransformerAbstractTest.php
+++ b/test/TransformerAbstractTest.php
@@ -300,7 +300,8 @@ class TransformerAbstractTest extends TestCase
 
         $transformer->setAvailableIncludes(['book']);
         $scope = new Scope($manager, new Item([], $transformer));
-        $included = $transformer->processIncludedResources($scope, []);
+
+        $this->assertFalse($transformer->processIncludedResources($scope, []));
     }
 
     /**


### PR DESCRIPTION
This allows the `0.x` series of Fractal to have passing tests without errors on PHP 5.4 all the way up to PHP 7.3.

I added an allowance for using the PHPUnit 7 series on versions of PHP that support it, and I made a few slight changes to tests and `phpunit.xml.dist` that allow the tests to continue running on both the older version of PHPUnit and the newer versions.

FYI, when you choose to upgrade to PHPUnit 8.x for the `1.x` series of this library, you'll need to make more changes to the tests that won't be backwards compatible with earlier versions of PHPUnit.