### PR TITLE
update travis to allow failures on 54 and 55

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
 
   allow_failures:
     - php: hhvm
+    - php: 5.4
+    - php: 5.5
+
 
 install:
   - travis_retry composer install --no-interaction --prefer-source


### PR DESCRIPTION
php 5.4 and 5.5 are long dead however there is a chance some people are still using it in production. We don't really want to worry about it, so we will let Travis allow these failures on code checks. 