### PR TITLE
Fix tests for PHP 5.4 and 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ sudo: false
 matrix:
   include:
     - php: 5.4
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.6
       env: COLLECT_COVERAGE=true
     - php: 7.0
@@ -17,8 +19,6 @@ matrix:
 
   allow_failures:
     - php: hhvm
-    - php: 5.4
-    - php: 5.5
 
 
 install:


### PR DESCRIPTION
We should have tests required for PHP 5.4 and 5.5 as they are officially supported versions. I'm using this PR to get them working.