### PR TITLE
Fix phpDoc typehint for resource key

### DIFF
--- a/src/Resource/ResourceAbstract.php
+++ b/src/Resource/ResourceAbstract.php
@@ -32,7 +32,7 @@ abstract class ResourceAbstract implements ResourceInterface
     /**
      * The resource key.
      *
-     * @var string
+     * @var string|null
      */
     protected $resourceKey;
 
@@ -48,7 +48,7 @@ abstract class ResourceAbstract implements ResourceInterface
      *
      * @param mixed                             $data
      * @param callable|TransformerAbstract|null $transformer
-     * @param string                            $resourceKey
+     * @param string|null                       $resourceKey
      */
     public function __construct($data = null, $transformer = null, $resourceKey = null)
     {
@@ -106,7 +106,7 @@ abstract class ResourceAbstract implements ResourceInterface
     /**
      * Get the resource key.
      *
-     * @return string
+     * @return string|null
      */
     public function getResourceKey()
     {
@@ -169,7 +169,7 @@ abstract class ResourceAbstract implements ResourceInterface
     /**
      * Set the resource key.
      *
-     * @param string $resourceKey
+     * @param string|null $resourceKey
      *
      * @return $this
      */

--- a/src/Resource/ResourceInterface.php
+++ b/src/Resource/ResourceInterface.php
@@ -16,7 +16,7 @@ interface ResourceInterface
     /**
      * Get the resource key.
      *
-     * @return string
+     * @return string|null
      */
     public function getResourceKey();
 

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -534,7 +534,7 @@ class Scope implements \JsonSerializable
      *
      * @internal
      *
-     * @return string
+     * @return string|null
      */
     protected function getResourceType()
     {

--- a/src/Serializer/ArraySerializer.php
+++ b/src/Serializer/ArraySerializer.php
@@ -33,8 +33,8 @@ class ArraySerializer extends SerializerAbstract
     /**
      * Serialize an item.
      *
-     * @param string $resourceKey
-     * @param array  $data
+     * @param string|null $resourceKey
+     * @param array       $data
      *
      * @return array
      */

--- a/src/Serializer/DataArraySerializer.php
+++ b/src/Serializer/DataArraySerializer.php
@@ -29,8 +29,8 @@ class DataArraySerializer extends ArraySerializer
     /**
      * Serialize an item.
      *
-     * @param string $resourceKey
-     * @param array  $data
+     * @param string|null $resourceKey
+     * @param array       $data
      *
      * @return array
      */

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -53,8 +53,8 @@ class JsonApiSerializer extends ArraySerializer
     /**
      * Serialize an item.
      *
-     * @param string $resourceKey
-     * @param array $data
+     * @param string|null $resourceKey
+     * @param array       $data
      *
      * @return array
      */

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -10,8 +10,8 @@ interface Serializer
     /**
      * Serialize a collection.
      *
-     * @param string $resourceKey
-     * @param array $data
+     * @param string|null $resourceKey
+     * @param array       $data
      *
      * @return array
      */

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -20,8 +20,8 @@ abstract class SerializerAbstract implements Serializer
     /**
      * Serialize a collection.
      *
-     * @param string $resourceKey
-     * @param array  $data
+     * @param string|null $resourceKey
+     * @param array       $data
      *
      * @return array
      */
@@ -30,8 +30,8 @@ abstract class SerializerAbstract implements Serializer
     /**
      * Serialize an item.
      *
-     * @param string $resourceKey
-     * @param array  $data
+     * @param string|null $resourceKey
+     * @param array       $data
      *
      * @return array
      */


### PR DESCRIPTION
The resource key is actually nullable which was not reflected in the docblock yet.

I am not sure if this should be targeted at master or 1.0, so please feel free to request me to change it.