### PR TITLE
Fix parseRelationships bug with collections

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -363,8 +363,8 @@ class JsonApiSerializer extends ArraySerializer
         foreach ($includedData as $key => $inclusion) {
             foreach ($inclusion as $includeKey => $includeObject) {
                 $relationships = $this->buildRelationships($includeKey, $relationships, $includeObject, $key);
-                if (isset($includedData[0][$includeKey]['meta'])) {
-                    $relationships[$includeKey][0]['meta'] = $includedData[0][$includeKey]['meta'];
+                if (isset($includedData[$key][$includeKey]['meta'])) {
+                    $relationships[$includeKey][$key]['meta'] = $includedData[$key][$includeKey]['meta'];
                 }
             }
         }

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -2643,6 +2643,95 @@ class JsonApiSerializerTest extends TestCase
         $this->assertSame($expectedJson, $scope->toJson());
     }
 
+
+    public function testParseRelationshipCollection()
+    {
+        $manager = new Manager();
+        $manager->setSerializer(new JsonApiSerializer());
+
+        $data = [
+            'data' => [
+                0 => [
+                    [
+                        'id' => 1,
+                        'type' => 'book',
+                        'meta' => []
+                    ],
+                ],
+                1 => [
+                    [
+                        'id' => 2,
+                        'type' => 'book',
+                        'meta' => []
+                    ],
+                ],
+                2 => [
+                    [
+                        'id' => 3,
+                        'type' => 'book',
+                        'meta' => []
+                    ]
+                ]
+            ]
+        ];
+
+        $includedData = [
+            0 => [
+                'inclusionKey' => [
+                    'data' => [
+                        0 => [
+                            'id' => 1,
+                            'type' => 'book',
+                            'meta' => []
+                        ]
+                    ],
+                    'meta' => [
+                        'entry' => 'entry1'
+                    ]
+                ]
+            ],
+            1 => [
+                'inclusionKey' => [
+                    'data' => [
+                        0 => [
+                            'id' => 2,
+                            'type' => 'book',
+                            'meta' => []
+                        ]
+                    ],
+                    'meta' => [
+                        'entry' => 'entry2'
+                    ]
+                ]
+            ],
+            2 => [
+                'inclusionKey' => [
+                    'data' => [
+                        0 => [
+                            'id' => 3,
+                            'type' => 'book',
+                            'meta' => []
+                        ]
+                    ],
+                    'meta' => [
+                        'entry' => 'entry3'
+                    ]
+                ]
+            ]
+        ];
+
+        $parsedRelationships = $manager->getSerializer()->injectData($data, $includedData);
+
+        $relationshipOneMeta = $parsedRelationships['data'][0]['relationships']['inclusionKey']['meta']['entry'];
+        $relationshipTwoMeta = $parsedRelationships['data'][1]['relationships']['inclusionKey']['meta']['entry'];
+        $relationshipThreeMeta = $parsedRelationships['data'][2]['relationships']['inclusionKey']['meta']['entry'];
+
+        $this->assertSame("entry1", $relationshipOneMeta);
+        $this->assertSame("entry2", $relationshipTwoMeta);
+        $this->assertSame("entry3", $relationshipThreeMeta);
+    }
+
+
     /**
      * @dataProvider serializingWithFieldsetsProvider
      */


### PR DESCRIPTION
This pull requests intends to fix a bug where certain items in a collection would not be given any metadata. This occurred because the parseRelationships method only looks at key 0, and therefore only every sets the metadata to the first item in the collection.