### PR TITLE
[gh-pages] Correct two overlooks in transformer's collection example

### DIFF
--- a/transformers.md
+++ b/transformers.md
@@ -267,28 +267,28 @@ use League\Fractal\ParamBag;
     public function includeComments(Book $book, ParamBag $params = null)
     {
         if ($params === null) {
-            return $book->comments;
+            $comments = $book->comments;
+        } else {
+            // Optional params validation
+            $usedParams = array_keys(iterator_to_array($params));
+            if ($invalidParams = array_diff($usedParams, $this->validParams)) {
+                throw new \Exception(sprintf(
+                    'Invalid param(s): "%s". Valid param(s): "%s"',
+                    implode(',', $usedParams),
+                    implode(',', $this->validParams)
+                ));
+            }
+
+            // Processing
+            list($limit, $offset) = $params->get('limit');
+            list($orderCol, $orderBy) = $params->get('order');
+
+            $comments = $book->comments
+                ->take($limit)
+                ->skip($offset)
+                ->orderBy($orderCol, $orderBy)
+                ->get();
         }
-
-    	// Optional params validation
-        $usedParams = array_keys(iterator_to_array($params));
-        if ($invalidParams = array_diff($usedParams, $this->validParams)) {
-            throw new \Exception(sprintf(
-                'Invalid param(s): "%s". Valid param(s): "%s"', 
-                implode(',', $usedParams), 
-                implode(',', $this->validParams)
-            ));
-        }
-
-    	// Processing
-        list($limit, $offset) = $params->get('limit');
-        list($orderCol, $orderBy) = $params->get('order');
-
-        $comments = $book->comments
-            ->take($limit)
-            ->skip($offset)
-            ->orderBy($orderCol, $orderBy)
-            ->get();
 
         return $this->collection($comments, new CommentTransformer);
     }

--- a/transformers.md
+++ b/transformers.md
@@ -262,7 +262,7 @@ use League\Fractal\ParamBag;
      *
      * @param Book $book
      * @param \League\Fractal\ParamBag|null
-     * @return \League\Fractal\Resource\Item
+     * @return \League\Fractal\Resource\Collection
      */
     public function includeComments(Book $book, ParamBag $params = null)
     {


### PR DESCRIPTION
1) Return type was wrong
2) When no parameters were given, comments weren't transformed.

Let me know if you need empty new lines added in the second commit, I'm always happy to edit my branch history.

---
https://github.com/thephpleague/fractal/blob/9c9c493edcf0f5438555e5b515a790749a26c807/src/TransformerAbstract.php#L279-L291