### PR TITLE
Add support for PHP 8.1

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -177,7 +177,7 @@ class Manager
         }
 
         foreach ($includes as $include) {
-            list($includeName, $allModifiersStr) = array_pad(explode(':', $include, 2), 2, null);
+            list($includeName, $allModifiersStr) = array_pad(explode(':', $include, 2), 2, '');
             list($allModifiersStr, $subRelations) = array_pad(explode('.', $allModifiersStr, 2), 2, null);
 
             // Trim it down to a cool level of recursion

--- a/src/ParamBag.php
+++ b/src/ParamBag.php
@@ -105,6 +105,7 @@ class ParamBag implements \ArrayAccess, \IteratorAggregate
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return $this->__isset($key);
@@ -117,6 +118,7 @@ class ParamBag implements \ArrayAccess, \IteratorAggregate
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->__get($key);
@@ -132,6 +134,7 @@ class ParamBag implements \ArrayAccess, \IteratorAggregate
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         throw new \LogicException('Modifying parameters is not permitted');
@@ -146,6 +149,7 @@ class ParamBag implements \ArrayAccess, \IteratorAggregate
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         throw new \LogicException('Modifying parameters is not permitted');
@@ -156,6 +160,7 @@ class ParamBag implements \ArrayAccess, \IteratorAggregate
      *
      * @return \ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->params);

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -295,7 +295,8 @@ class Scope implements \JsonSerializable
     /**
      * @return mixed
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->toArray();
     }


### PR DESCRIPTION
This fixes the following error on PHP 8.1 RC6:

```
Fatal error: During inheritance of JsonSerializable: Uncaught ErrorException: Return type of League\Fractal\Scope::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/league/fractal/src/Scope.php:298
```

Related to #526