### PR TITLE
Add ResourceInterface::getMeta()

### DIFF
--- a/src/Resource/ResourceInterface.php
+++ b/src/Resource/ResourceInterface.php
@@ -51,4 +51,11 @@ interface ResourceInterface
      * @return $this
      */
     public function setTransformer($transformer);
+
+    /**
+     * Get the meta data.
+     *
+     * @return array
+     */
+    public function getMeta();
 }


### PR DESCRIPTION
Breaking change. 

We use this method in `Scope::toArray()`. Should we include it into the interface or not?