### PR TITLE
Update supported versions in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,7 @@ $ composer require league/fractal
 
 The following versions of PHP are supported by this version.
 
-* PHP 5.4
-* PHP 5.5
-* PHP 5.6
-* PHP 7.0
-* PHP 7.1
-* PHP 7.2
-* HHVM
+* >= PHP 7.4
 
 ## Documentation
 


### PR DESCRIPTION
The supported versions in the readme are outdated after the `0.20` release.