### PR TITLE
Explicitly default TransformerAbstract::currentScope to null since it's not defined in the constructor

### DIFF
--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -38,7 +38,7 @@ abstract class TransformerAbstract
     /**
      * The transformer should know about the current scope, so we can fetch relevant params.
      */
-    protected ?Scope $currentScope;
+    protected ?Scope $currentScope = null;
 
     /**
      * Getter for availableIncludes.

--- a/test/TransformerAbstractTest.php
+++ b/test/TransformerAbstractTest.php
@@ -74,6 +74,16 @@ class TransformerAbstractTest extends TestCase
         $this->assertSame($transformer->getCurrentScope(), $scope);
     }
 
+    /**
+     * @covers \League\Fractal\TransformerAbstract::getCurrentScope
+     */
+    public function testCanAccessScopeBeforeInitialization()
+    {
+        $transformer = $this->getMockForAbstractClass('League\Fractal\TransformerAbstract');
+        $currentScope = $transformer->getCurrentScope();
+        $this->assertNull($currentScope);
+    }
+
     public function testProcessEmbeddedResourcesNoAvailableIncludes()
     {
         $transformer = m::mock('League\Fractal\TransformerAbstract')->makePartial();


### PR DESCRIPTION
This change adds an explicit default value to the `$currentScope` property of `TransformerAbstract` since it's not hydrated in the constructor.

- See psalm `MissingConstructor` issue: https://psalm.dev/r/639278ed1b (in reality, this can also flag a `PropertyNotSetInConstructor` issue)
- and 3v4l demonstrating the problem: https://3v4l.org/j5oVI#v7.4.28

I'd suggest this as a patch release, I can't see how this might break any existing functionality.