### PR TITLE
Fix sub relations when resource with modifier is included multiple times

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -134,10 +134,9 @@ class Manager
             // Trim it down to a cool level of recursion
             $includeName = $this->trimToAcceptableRecursionLevel($includeName);
 
-            if (in_array($includeName, $this->requestedIncludes)) {
-                continue;
+            if (!in_array($includeName, $this->requestedIncludes)) {
+                $this->requestedIncludes[] = $includeName;
             }
-            $this->requestedIncludes[] = $includeName;
 
             // No Params? Bored
             if ($allModifiersStr === null) {
@@ -164,10 +163,16 @@ class Manager
                 $modifierArr[$modifierName] = explode($this->paramDelimiter, $modifierParamStr);
             }
 
-            $this->includeParams[$includeName] = $modifierArr;
+            if (!isset($this->includeParams[$includeName])) {
+                $this->includeParams[$includeName] = $modifierArr;
+            }
 
             if ($subRelations) {
-                $this->requestedIncludes[] = $this->trimToAcceptableRecursionLevel($includeName . '.' . $subRelations);
+                $subRelationsIncludeName = $this->trimToAcceptableRecursionLevel($includeName . '.' . $subRelations);
+
+                if (!in_array($subRelationsIncludeName, $this->requestedIncludes)) {
+                    $this->requestedIncludes[] = $subRelationsIncludeName;
+                }
             }
         }
 

--- a/test/ManagerTest.php
+++ b/test/ManagerTest.php
@@ -95,6 +95,11 @@ class ManagerTest extends TestCase
         $this->assertInstanceOf('League\Fractal\ParamBag', $params);
 
         $this->assertSame(['1'], $params['modifier']);
+
+        // Two sub relations with parent using modifier
+        $manager->parseIncludes('foo:modifier.bar,foo:modifier.baz');
+
+        $this->assertSame(['foo', 'foo.bar', 'foo.baz'], $manager->getRequestedIncludes());
     }
 
     public function testParseExcludeSelfie()

--- a/test/ManagerTest.php
+++ b/test/ManagerTest.php
@@ -86,6 +86,15 @@ class ManagerTest extends TestCase
         $this->assertSame(['5', '1'], $params['limit']);
         $this->assertSame(['name'], $params['order']);
         $this->assertSame(['foo', 'foo.bar', 'baz'], $manager->getRequestedIncludes());
+
+        // The first relation modifier wins
+        $manager->parseIncludes('foo:modifier(1).bar,foo:modifier(2).baz');
+
+        $params = $manager->getIncludeParams('foo');
+
+        $this->assertInstanceOf('League\Fractal\ParamBag', $params);
+
+        $this->assertSame(['1'], $params['modifier']);
     }
 
     public function testParseExcludeSelfie()


### PR DESCRIPTION
When we try to include `foo:modifier.bar,foo:modifier.baz`, only `foo` and `foo.bar` get included, while `foo.baz` is ignored.

I believe this change is backward compatible, as I made sure `$this->includeParams` stays the same for `foo:modifier(1).bar,foo:modifier(2).baz`