### PR TITLE
Fixing memory leaks when fractal used in daemons

### DIFF
--- a/src/Resource/ResourceAbstract.php
+++ b/src/Resource/ResourceAbstract.php
@@ -110,7 +110,7 @@ abstract class ResourceAbstract implements ResourceInterface
     /**
      * Set the transformer.
      *
-     * @param callable|TransformerAbstract $transformer
+     * @param callable|TransformerAbstract|null $transformer
      */
     public function setTransformer($transformer): self
     {

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -269,7 +269,7 @@ class Scope implements \JsonSerializable
         } elseif (is_callable($transformer)) {
             $transformedData = call_user_func($transformer, $data);
         } else {
-            $transformer->setCurrentScope($this);
+            $transformer->setCurrentScope($this->getCurrentScopeWithoutTransformer());
             $transformedData = $transformer->transform($data);
         }
 
@@ -353,7 +353,7 @@ class Scope implements \JsonSerializable
         if (is_callable($transformer)) {
             $transformedData = call_user_func($transformer, $data);
         } else {
-            $transformer->setCurrentScope($this);
+            $transformer->setCurrentScope($this->getCurrentScopeWithoutTransformer());
             $transformedData = $transformer->transform($data);
         }
 
@@ -461,5 +461,18 @@ class Scope implements \JsonSerializable
     protected function getResourceType(): string
     {
         return $this->resource->getResourceKey();
+    }
+
+    /**
+     * Return current scope with null transformer (due to memory leak)
+     *
+     * @return Scope
+     */
+    private function getCurrentScopeWithoutTransformer(): Scope
+    {
+        $scopeWithoutTransformer = clone $this;
+        $scopeWithoutTransformer->getResource()->setTransformer(null);
+
+        return $scopeWithoutTransformer;
     }
 }


### PR DESCRIPTION
Due to every transformer being filled with the current scope, there is a reference recursion.

`Transformer -> Scope -> Resource -> Transformer -> Scope...`

This causes memory leaks in daemons and workers, I guess because GC is not able to collect these cyclomatic references; even running `gc_collect_cycles` after each job is not helping.

I think this is not breaking change, but kind of messy. Begging for comments and help with this issue