### PR TITLE
Correct parameter name

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -182,7 +182,7 @@ API users do not try and do anything too clever with them. They just need to pas
 
 On the next request, we move the cursor forward.
 
- * Set `cursor` to `next` from the last response
+ * Set `current` to `next` from the last response
  * Set `previous` to `current` from the last response
  * `limit` is optional
  	* You can set it to `count` from the previous request to maintain the same limit


### PR DESCRIPTION
In the docs there is a reference to `cursor` which is the name of the object. I believe the correct parameter that should be referred to is `current`