### PR TITLE
Compatibility up to PHP8.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-20.04]
-        php: [7.4, 8.0, 8.1]
+        php: [7.4, 8.0, 8.1, 8.2]
 
     name: League - PHP ${{ matrix.php }} on ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-20.04]
-        php: [7.4, 8.0, 8.1, 8.2]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
 
     name: League - PHP ${{ matrix.php }} on ${{ matrix.os }}
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -61,7 +61,7 @@ class Manager
      */
     private ScopeFactoryInterface $scopeFactory;
 
-    public function __construct(ScopeFactoryInterface $scopeFactory = null)
+    public function __construct(?ScopeFactoryInterface $scopeFactory = null)
     {
         $this->scopeFactory = $scopeFactory ?: new ScopeFactory();
     }
@@ -72,7 +72,7 @@ class Manager
     public function createData(
         ResourceInterface $resource,
         ?string $scopeIdentifier = null,
-        Scope $parentScopeInstance = null
+        ?Scope $parentScopeInstance = null
     ): Scope {
         if ($parentScopeInstance !== null) {
             return $this->scopeFactory->createChildScopeFor($this, $parentScopeInstance, $resource, $scopeIdentifier);

--- a/src/Pagination/DoctrinePaginatorAdapter.php
+++ b/src/Pagination/DoctrinePaginatorAdapter.php
@@ -73,7 +73,11 @@ class DoctrinePaginatorAdapter implements PaginatorInterface
      */
     public function getCount(): int
     {
-        return $this->paginator->count();
+        $iterator = $this->paginator->getIterator();
+
+        return (is_countable($iterator))
+            ? count($iterator)
+            : iterator_count(clone $iterator);
     }
 
     /**

--- a/src/Pagination/DoctrinePaginatorAdapter.php
+++ b/src/Pagination/DoctrinePaginatorAdapter.php
@@ -73,7 +73,7 @@ class DoctrinePaginatorAdapter implements PaginatorInterface
      */
     public function getCount(): int
     {
-        return $this->paginator->getIterator()->count();
+        return $this->paginator->count();
     }
 
     /**

--- a/test/Pagination/DoctrinePaginatorAdapterTest.php
+++ b/test/Pagination/DoctrinePaginatorAdapterTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace League\Fractal\Test\Pagination;
 
-use Doctrine\ORM\Query;
+use ArrayIterator;
 use League\Fractal\Pagination\DoctrinePaginatorAdapter;
 use Mockery;
 use PHPUnit\Framework\TestCase;
@@ -28,10 +28,8 @@ class DoctrinePaginatorAdapterTest extends TestCase
         $paginator->shouldReceive('getQuery')->andReturn($query);
 
         //Mock the iterator of the paginator
-        $iterator = Mockery::mock('IteratorAggregate');
-        $iterator->shouldReceive('count')->andReturn($count);
+        $iterator = new ArrayIterator(range(1, $count));
         $paginator->shouldReceive('getIterator')->andReturn($iterator);
-
 
         $adapter = new DoctrinePaginatorAdapter($paginator, function ($page) {
             return 'http://example.com/foo?page='.$page;


### PR DESCRIPTION
This PR resolves deprecation warnings in PHP8.4 and adds tests for versions up to PHP8.4.

It includes changes from #568 for simplicity.