### PR TITLE
Fix deprecated errors in tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-20.04]
-        php: [7.4, 8.0, 8.1]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
 
     name: League - PHP ${{ matrix.php }} on ${{ matrix.os }}
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -37,7 +37,7 @@ jobs:
           php-version: 8.1
           extensions: apcu, redis
           coverage: none
-          tools: vimeo/psalm:4.22.0
+          tools: vimeo/psalm:4.30.0
 
       - name: Download dependencies
         uses: ramsey/composer-install@v1

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 build
 vendor
 .phpunit.result.cache
+.idea

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "~3.4",
-        "vimeo/psalm": "^4.22"
+        "vimeo/psalm": "^4.30"
     },
     "suggest": {
         "illuminate/pagination": "The Illuminate Pagination component.",

--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,18 @@
     "require-dev": {
         "doctrine/orm": "^2.5",
         "illuminate/contracts": "~5.0",
+        "laminas/laminas-paginator": "~2.12",
         "mockery/mockery": "^1.3",
-        "pagerfanta/pagerfanta": "~1.0.0",
+        "pagerfanta/pagerfanta": "~1.0.0|~4.0.0",
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "~3.4",
-        "vimeo/psalm": "^4.22",
-        "zendframework/zend-paginator": "~2.3"
+        "vimeo/psalm": "^4.22"
     },
     "suggest": {
         "illuminate/pagination": "The Illuminate Pagination component.",
         "pagerfanta/pagerfanta": "Pagerfanta Paginator",
-        "zendframework/zend-paginator": "Zend Framework Paginator"
+        "laminas/laminas-paginator": "Laminas Framework Paginator"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,3 +6,5 @@ parameters:
   reportUnmatchedIgnoredErrors: false
   paths:
     - src
+  bootstrapFiles:
+    - test/phpstan.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -8,6 +8,7 @@
     errorBaseline="psalm.baseline.xml"
 >
     <projectFiles>
+        <file name="test/phpstan.php" />
         <directory name="src" />
         <ignoreFiles>
             <directory name="vendor" />

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -61,7 +61,7 @@ class Manager
      */
     private ScopeFactoryInterface $scopeFactory;
 
-    public function __construct(ScopeFactoryInterface $scopeFactory = null)
+    public function __construct(?ScopeFactoryInterface $scopeFactory = null)
     {
         $this->scopeFactory = $scopeFactory ?: new ScopeFactory();
     }
@@ -72,7 +72,7 @@ class Manager
     public function createData(
         ResourceInterface $resource,
         ?string $scopeIdentifier = null,
-        Scope $parentScopeInstance = null
+        ?Scope $parentScopeInstance = null
     ): Scope {
         if ($parentScopeInstance !== null) {
             return $this->scopeFactory->createChildScopeFor($this, $parentScopeInstance, $resource, $scopeIdentifier);

--- a/src/Pagination/DoctrinePaginatorAdapter.php
+++ b/src/Pagination/DoctrinePaginatorAdapter.php
@@ -19,7 +19,7 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
  */
 class DoctrinePaginatorAdapter implements PaginatorInterface
 {
-    use TraversableCountTrait;
+    use PaginatorCountTrait;
 
     /**
      * The paginator instance.

--- a/src/Pagination/DoctrinePaginatorAdapter.php
+++ b/src/Pagination/DoctrinePaginatorAdapter.php
@@ -19,6 +19,8 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
  */
 class DoctrinePaginatorAdapter implements PaginatorInterface
 {
+    use TraversableCountTrait;
+
     /**
      * The paginator instance.
      * @var  Paginator
@@ -73,7 +75,7 @@ class DoctrinePaginatorAdapter implements PaginatorInterface
      */
     public function getCount(): int
     {
-        return $this->paginator->getIterator()->count();
+        return $this->getTraversableCount($this->paginator->getIterator());
     }
 
     /**
@@ -93,7 +95,7 @@ class DoctrinePaginatorAdapter implements PaginatorInterface
     }
 
     /**
-     * Get the the route generator.
+     * Get the route generator.
      */
     private function getRouteGenerator(): callable
     {

--- a/src/Pagination/LaminasPaginatorAdapter.php
+++ b/src/Pagination/LaminasPaginatorAdapter.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the League\Fractal package.
+ *
+ * (c) Phil Sturgeon <me@philsturgeon.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\Fractal\Pagination;
+
+use Laminas\Paginator\Paginator;
+
+/**
+ * A paginator adapter for laminas/laminas-paginator.
+ *
+ * @author Abdul Malik Ikhsan <samsonasik@gmail.com>
+ */
+class LaminasPaginatorAdapter implements PaginatorInterface
+{
+    protected Paginator $paginator;
+
+    /**
+     * The route generator.
+     *
+     * @var callable
+     */
+    protected $routeGenerator;
+
+    public function __construct(Paginator $paginator, callable $routeGenerator)
+    {
+        $this->paginator = $paginator;
+        $this->routeGenerator = $routeGenerator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCurrentPage(): int
+    {
+        return $this->paginator->getCurrentPageNumber();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getLastPage(): int
+    {
+        return $this->paginator->count();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTotal(): int
+    {
+        return $this->paginator->getTotalItemCount();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCount(): int
+    {
+        return $this->paginator->getCurrentItemCount();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPerPage(): int
+    {
+        return $this->paginator->getItemCountPerPage();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getUrl(int $page): string
+    {
+        return call_user_func($this->routeGenerator, $page);
+    }
+
+    public function getPaginator(): Paginator
+    {
+        return $this->paginator;
+    }
+
+    public function getRouteGenerator(): callable
+    {
+        return $this->routeGenerator;
+    }
+}

--- a/src/Pagination/PagerfantaPaginatorAdapter.php
+++ b/src/Pagination/PagerfantaPaginatorAdapter.php
@@ -20,6 +20,8 @@ use Pagerfanta\Pagerfanta;
  */
 class PagerfantaPaginatorAdapter implements PaginatorInterface
 {
+    use PaginatorCountTrait;
+
     protected Pagerfanta $paginator;
 
     /**
@@ -64,7 +66,7 @@ class PagerfantaPaginatorAdapter implements PaginatorInterface
      */
     public function getCount(): int
     {
-        return count($this->paginator->getCurrentPageResults());
+        return $this->getIterableCount($this->paginator->getCurrentPageResults());
     }
 
     /**

--- a/src/Pagination/PaginatorCountTrait.php
+++ b/src/Pagination/PaginatorCountTrait.php
@@ -2,8 +2,20 @@
 
 namespace League\Fractal\Pagination;
 
-trait TraversableCountTrait
+trait PaginatorCountTrait
 {
+    /**
+     * Safely get the count from an iterable
+     */
+    private function getIterableCount(iterable $iterable): int
+    {
+        if ($iterable instanceof \Traversable) {
+            return $this->getTraversableCount($iterable);
+        }
+
+        return count($iterable);
+    }
+
     /**
      * Safely get the count from a traversable
      */

--- a/src/Pagination/TraversableCountTrait.php
+++ b/src/Pagination/TraversableCountTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace League\Fractal\Pagination;
+
+trait TraversableCountTrait
+{
+    /**
+     * Safely get the count from a traversable
+     */
+    private function getTraversableCount(\Traversable $traversable): int
+    {
+        if ($traversable instanceof \Countable) {
+            return count($traversable);
+        }
+
+        // Call the "count" method if it exists
+        if (method_exists($traversable, 'count')) {
+            return $traversable->count();
+        }
+
+        // If not, fall back to iterator_count and rewind if possible
+        $count = iterator_count($traversable);
+        if ($traversable instanceof \Iterator || $traversable instanceof \IteratorAggregate) {
+            $traversable->rewind();
+        }
+
+        return $count;
+    }
+
+}

--- a/test/Pagination/LaminasFrameworkPaginatorAdapterTest.php
+++ b/test/Pagination/LaminasFrameworkPaginatorAdapterTest.php
@@ -1,18 +1,12 @@
 <?php
 namespace League\Fractal\Test\Pagination;
 
-use League\Fractal\Pagination\ZendFrameworkPaginatorAdapter;
+use League\Fractal\Pagination\LaminasPaginatorAdapter;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
-class ZendFrameworkPaginatorAdapterTest extends TestCase
+class LaminasFrameworkPaginatorAdapterTest extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        class_alias(\Laminas\Paginator\Adapter\ArrayAdapter::class, \Zend\Paginator\Adapter\ArrayAdapter::class);
-        class_alias(\Laminas\Paginator\Paginator::class, \Zend\Paginator\Paginator::class);
-    }
-
     public function testPaginationAdapter()
     {
         $items = [
@@ -23,7 +17,7 @@ class ZendFrameworkPaginatorAdapterTest extends TestCase
             'Item 41', 'Item 42', 'Item 43', 'Item 44', 'Item 45', 'Item 46', 'Item 47', 'Item 48', 'Item 49', 'Item 50',
         ];
 
-        $adapter = Mockery::mock('Zend\Paginator\Adapter\ArrayAdapter', [$items])->makePartial();
+        $adapter = Mockery::mock('Laminas\Paginator\Adapter\ArrayAdapter', [$items])->makePartial();
 
         $total = 50;
         $count = 10;
@@ -31,13 +25,13 @@ class ZendFrameworkPaginatorAdapterTest extends TestCase
         $currentPage = 2;
         $lastPage = 5;
 
-        $paginator = Mockery::mock('Zend\Paginator\Paginator', [$adapter])->makePartial();
+        $paginator = Mockery::mock('Laminas\Paginator\Paginator', [$adapter])->makePartial();
 
         $paginator->shouldReceive('getCurrentPageNumber')->andReturn($currentPage);
         $paginator->shouldReceive('count')->andReturn($lastPage);
         $paginator->shouldReceive('getItemCountPerPage')->andReturn($perPage);
 
-        $adapter = new ZendFrameworkPaginatorAdapter($paginator, function ($page) {
+        $adapter = new LaminasPaginatorAdapter($paginator, function ($page) {
             return 'http://example.com/foo?page='.$page;
         });
 

--- a/test/Pagination/PaginatorCountTraitTest.php
+++ b/test/Pagination/PaginatorCountTraitTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace League\Fractal\Test\Pagination;
+
+use League\Fractal\Pagination\PaginatorCountTrait;
+use League\Fractal\Test\Stub\SimpleTraversable;
+use PHPUnit\Framework\TestCase;
+
+class PaginatorCountTraitTest extends TestCase
+{
+    protected $instance;
+
+    /** @before */
+    public function before()
+    {
+        $this->instance = new class() {
+            use PaginatorCountTrait;
+
+            public function getIterableCountPublic(iterable $iterable)
+            {
+                return $this->getIterableCount($iterable);
+            }
+
+            public function getTraversableCountPublic(\Traversable $traversable)
+            {
+                return $this->getTraversableCount($traversable);
+            }
+        };
+    }
+
+    /**
+     * @dataProvider arrayProvider
+     */
+    public function testSupportsIterables(array $data)
+    {
+        $count = count($data);
+        $this->assertEquals($count, $this->instance->getIterableCountPublic($data));
+        $this->assertEquals($count, $this->instance->getIterableCountPublic(new \ArrayIterator($data)));
+        $this->assertEquals($count, $this->instance->getIterableCountPublic(new SimpleTraversable($data)));
+    }
+
+    /**
+     * @dataProvider arrayProvider
+     */
+    public function testSupportsTraversables(array $data)
+    {
+        $count = count($data);
+        $this->assertEquals($count, $this->instance->getTraversableCountPublic(new \ArrayIterator($data)));
+        $this->assertEquals($count, $this->instance->getTraversableCountPublic(new SimpleTraversable($data)));
+    }
+
+    public function arrayProvider()
+    {
+        return [
+            [[]],
+            [[1, 2, 3]],
+            [range(1, 100)],
+        ];
+    }
+}

--- a/test/Serializer/DataArraySerializerTest.php
+++ b/test/Serializer/DataArraySerializerTest.php
@@ -357,15 +357,6 @@ class DataArraySerializerTest extends TestCase
         $this->assertSame($expected, $scope->toArray());
     }
 
-    public function testCanPassNullValueToSerializer()
-    {
-        $testClass = new \stdClass();
-        $testClass->name = 'test';
-        $testClass->email = 'test@test.com';
-
-
-    }
-
     public function tearDown(): void
     {
         Mockery::close();

--- a/test/Stub/SimpleTraversable.php
+++ b/test/Stub/SimpleTraversable.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace League\Fractal\Test\Stub;
+
+class SimpleTraversable implements \Iterator
+{
+    private $list;
+    private $keys;
+    private $cursor = 0;
+
+    public function __construct(array $list)
+    {
+        $this->list = array_values($list);
+        $this->keys = array_keys($list);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function current()
+    {
+        return $this->list[$this->cursor];
+    }
+
+    public function next(): void
+    {
+        $this->cursor++;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function key()
+    {
+        return $this->keys[$this->cursor];
+    }
+
+    public function valid(): bool
+    {
+        return isset($this->list[$this->cursor]);
+    }
+
+    public function rewind(): void
+    {
+        $this->cursor = 0;
+    }
+}

--- a/test/phpstan.php
+++ b/test/phpstan.php
@@ -1,0 +1,4 @@
+<?php
+
+class_alias(\Laminas\Paginator\Adapter\ArrayAdapter::class, \Zend\Paginator\Adapter\ArrayAdapter::class);
+class_alias(\Laminas\Paginator\Paginator::class, \Zend\Paginator\Paginator::class);


### PR DESCRIPTION
This PR fixes deprecated errors and resolved #574 by:

1. Updating typed arguments that have `= null` but don't have a nullable type
2. Allowing newer versions of Pagerfanta in dev dependencies.
3. Switching from Zend to Laminas in tests, which is fully compatible. In doing so I also duplicated the Zend paginator adapter for use with Laminas

This PR builds on the changes from #572