### PR TITLE
Don't allow JsonApiSerilizer to include empty attributes on serialization

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -67,7 +67,7 @@ class JsonApiSerializer extends ArraySerializer
         }
 
         if (empty($resource['data']['attributes'])) {
-            $resource['data']['attributes'] = (object) [];
+            unset($resource['data']['attributes']);
         }
 
         if ($this->shouldIncludeLinks()) {

--- a/test/Serializer/JsonApiSerializerTest.php
+++ b/test/Serializer/JsonApiSerializerTest.php
@@ -2626,7 +2626,7 @@ class JsonApiSerializerTest extends TestCase
         $this->assertSame(json_encode($expected), $scope->toJson());
     }
 
-    public function testEmptyAttributesIsObject()
+    public function testShouldNotIncludeEmptyAttributesOnResponse()
     {
         $manager = new Manager();
         $manager->setSerializer(new JsonApiSerializer());
@@ -2637,7 +2637,7 @@ class JsonApiSerializerTest extends TestCase
 
         $scope = new Scope($manager, $resource);
 
-        $expectedJson = '{"data":{"type":"resources","id":"1","attributes":{}}}';
+        $expectedJson = '{"data":{"type":"resources","id":"1"}}';
 
         $this->assertSame($expectedJson, $scope->toJson());
     }


### PR DESCRIPTION
This PR address the issue https://github.com/thephpleague/fractal/issues/577