### PR TITLE
Unset scopes from transformers after transforming to avoid memory leak

### DIFF
--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -219,6 +219,13 @@ abstract class TransformerAbstract
         return $this;
     }
 
+    public function unsetCurrentScope(): self
+    {
+        $this->currentScope = null;
+
+        return $this;
+    }
+
     /**
      * Create a new primitive resource object.
      *

--- a/test/MemoryTest.php
+++ b/test/MemoryTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace League\Fractal\Test;
+
+use League\Fractal\Manager;
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\Item;
+use League\Fractal\Resource\Primitive;
+use League\Fractal\Resource\ResourceInterface;
+use League\Fractal\Scope;
+use League\Fractal\ScopeFactoryInterface;
+use League\Fractal\TransformerAbstract;
+use PHPUnit\Framework\TestCase;
+
+class MemoryTest extends TestCase
+{
+    /**
+     * @dataProvider TransformerProvider
+     */
+    public function testDoesntLeak(ResourceInterface $resource, TransformerAbstract $transformer): void
+    {
+        $resource->setTransformer($transformer);
+        $scopeFactory = \Mockery::mock(ScopeFactoryInterface::class);
+        $manager = new Manager($scopeFactory);
+        $scope = new Scope($manager, $resource, 'main');
+        $subScope = new Scope($manager, new Collection([]), 'sub');
+        $scopeFactory->shouldReceive('createScopeFor')->andReturn($scope);
+        $scopeFactory->shouldReceive('createChildScopeFor')->andReturn($subScope);
+
+        if ($resource instanceof Primitive) {
+            $manager->createData($resource)->transformPrimitiveResource();
+        } else {
+            $manager->createData($resource)->toArray();
+        }
+        $this->assertEquals($scope, $transformer->givenScope ?? null);
+
+        if ($transformer->getDefaultIncludes() !== []) {
+            $this->assertEquals($resource instanceof Primitive ? null : $scope, $transformer->givenSubScope ?? null);
+        }
+        $this->assertNull($transformer->getCurrentScope());
+    }
+
+    public function TransformerProvider(): \Generator
+    {
+        $basicTransformer = function () {
+            return new class extends TransformerAbstract {
+                public $givenScope = null;
+                public $givenSubScope = null;
+
+                public function transform($data)
+                {
+                    $this->givenScope = $this->getCurrentScope();
+                    return $data;
+                }
+
+                public function includeFoo(): ResourceInterface
+                {
+                    $this->givenSubScope = $this->getCurrentScope();
+                    return new Item(['foo'], $this);
+                }
+            };
+        };
+        $resources = [
+            new Primitive('foo'),
+            new Collection([['a' => 'b'], ['c' => 'd']]),
+            new Item(['foo', 'bar', 'baz']),
+        ];
+
+        foreach ($resources as $resource) {
+            yield [$resource, $basicTransformer()];
+        }
+
+        foreach ($resources as $resource) {
+            $transformer = $basicTransformer();
+            $transformer->setDefaultIncludes(['foo']);
+            yield [$resource, $transformer];
+        }
+    }
+
+    public function testScopeHasNoStrongReferences(): void
+    {
+        $transformer = new class extends TransformerAbstract {
+            public \WeakReference $givenScope;
+            public function transform($data)
+            {
+                $this->givenScope = \WeakReference::create($this->getCurrentScope());
+                return $data;
+            }
+        };
+
+        $resource = new Item(['foo', 'bar', 'baz'], $transformer);
+        $manager = new Manager();
+
+        $manager->createData($resource)->toArray();
+
+        gc_collect_cycles();
+        $this->assertNull($transformer->getCurrentScope());
+        $this->assertNull($transformer->givenScope->get());
+    }
+
+}


### PR DESCRIPTION
This change ensures scopes don't remain set against transformers for longer than they need to be.

There were a few different options I considered:
1. Unsetting the scope after finishing transform (This is what I chose)
2. Using a `\WeakReference` on the transformer rather than referencing the scope directly
3. Removing the `->setCurrentScope` entirely and using `\Reflection(Function|Method)` to determine how and when to pass the `Scope` to transform calls

| Option | Prevents Leaks | Backwards compatible | Doesn't impact performance | Ideal DX |
| - | - | - | - | - |
| Unsetting | ✅ | ✅<sup>[1]</sup> | ✅ | ❌ | 
| `\WeakReference | ✅ | ❌<sup>[2]</sup> | ✅ | ❌ |
| `\Reflection` | ✅ | ❌ | ❌<sup>[3]</sup> | ✅ |

- [1]: This change makes it so that you can't access the current scope _after_ transform has completed. Instead the author of the transformer needs to manually capture the scope themselves using `->getCurrentScope()` during the transform if they need to have the scope available so late.
- [2]: The only impact is that Transformer authors would no longer be able to access `$this->currentScope`, which isn't really a huge deal given that we already have `->getCurrentScope()` available, but it is a BC break.
- [3]: While the impact is minimal, there is certainly an impact to using reflection for every single `->transform` / `->include...` call.

Replaces #563, #569